### PR TITLE
Fix reverse migration for migrations 0002, 0003

### DIFF
--- a/nautobot_device_onboarding/migrations/0002_create_onboardingdevice.py
+++ b/nautobot_device_onboarding/migrations/0002_create_onboardingdevice.py
@@ -16,5 +16,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_missing_onboardingdevice),
+        migrations.RunPython(create_missing_onboardingdevice, migrations.RunPython.noop),
     ]

--- a/nautobot_device_onboarding/migrations/0003_onboardingtask_label.py
+++ b/nautobot_device_onboarding/migrations/0003_onboardingtask_label.py
@@ -21,5 +21,5 @@ class Migration(migrations.Migration):
             name="label",
             field=models.PositiveIntegerField(default=0, editable=False),
         ),
-        migrations.RunPython(create_labels_for_existing_tasks),
+        migrations.RunPython(create_labels_for_existing_tasks, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
Fixes reverse migrations for 0002, 0003

Closes #70 

The `RunPython` was only used to populate already existing columns. We are good to go with leaving this data as it is and let it be removed by django.

```
root@e24fdf1c31ef:/source# nautobot-server migrate nautobot_device_onboarding zero
Operations to perform:
  Unapply all migrations: nautobot_device_onboarding
Running migrations:
  Rendering model states... DONE
  Unapplying nautobot_device_onboarding.0003_onboardingtask_label... OK
  Unapplying nautobot_device_onboarding.0002_create_onboardingdevice... OK
  Unapplying nautobot_device_onboarding.0001_initial... OK
root@e24fdf1c31ef:/source#
```