### PR TITLE
Add OnboardingTask status and failure reason metrics!

### DIFF
--- a/nautobot_device_onboarding/metrics.py
+++ b/nautobot_device_onboarding/metrics.py
@@ -1,6 +1,33 @@
-"""Plugin additions to the Nautobot navigation menu."""
+"""Plugin metrics."""
+
 from prometheus_client import Counter
+
+from prometheus_client.metrics_core import GaugeMetricFamily
+
+from nautobot_device_onboarding.choices import OnboardingStatusChoices, OnboardingFailChoices
+from nautobot_device_onboarding.models import OnboardingTask, OnboardingDevice
+
+METRICS_PREFIX = "deviceonboarding_"
 
 onboardingtask_results_counter = Counter(
     name="onboardingtask_results_total", documentation="Count of results for Onboarding Task", labelnames=("status",)
 )
+
+def current_onboarding_results():
+    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_results_count", "Device Onboarding Task Results", labels=["name"])
+    
+    results_gauges.add_metric(labels=["total"],value=OnboardingTask.objects.count())
+    for status_choice in OnboardingStatusChoices.CHOICES:
+        results_gauges.add_metric(labels=[status_choice[0]], value=OnboardingTask.objects.filter(status=status_choice[0]).count())
+
+    yield results_gauges
+
+def current_onboarding_failures():
+    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_failure_count", "Device Onboarding Failures", labels=["name"])
+
+    for failure_choice in OnboardingFailChoices.CHOICES:
+        results_gauges.add_metric(labels=[failure_choice[0]], value=OnboardingTask.objects.filter(failed_reason=failure_choice[0]).count())
+        
+    yield results_gauges
+
+metrics = [current_onboarding_results, current_onboarding_failures]

--- a/nautobot_device_onboarding/metrics.py
+++ b/nautobot_device_onboarding/metrics.py
@@ -5,7 +5,7 @@ from prometheus_client import Counter
 from prometheus_client.metrics_core import GaugeMetricFamily
 
 from nautobot_device_onboarding.choices import OnboardingStatusChoices, OnboardingFailChoices
-from nautobot_device_onboarding.models import OnboardingTask, OnboardingDevice
+from nautobot_device_onboarding.models import OnboardingTask
 
 METRICS_PREFIX = "deviceonboarding_"
 
@@ -15,16 +15,21 @@ onboardingtask_results_counter = Counter(
     name="onboardingtask_results_total", documentation="Count of results for Onboarding Task", labelnames=("status",)
 )
 
+
 def current_onboarding_results():
-    """Creates a gauge metric for Onboarding Task Results.
-    """
-    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_results_count", "Device Onboarding Task Results", labels=["status"])
-    
-    results_gauges.add_metric(labels=["total"],value=OnboardingTask.objects.count())
+    """Creates a gauge metric for Onboarding Task Results."""
+    results_gauges = GaugeMetricFamily(
+        f"{METRICS_PREFIX}onboardtask_results_count", "Device Onboarding Task Results", labels=["status"]
+    )
+
+    results_gauges.add_metric(labels=["total"], value=OnboardingTask.objects.count())
     for status_choice in OnboardingStatusChoices.CHOICES:
-        results_gauges.add_metric(labels=[status_choice[0]], value=OnboardingTask.objects.filter(status=status_choice[0]).count())
+        results_gauges.add_metric(
+            labels=[status_choice[0]], value=OnboardingTask.objects.filter(status=status_choice[0]).count()
+        )
 
     yield results_gauges
+
 
 def current_onboarding_failures():
     """Creates a gauge metric for Onboarding Task failures.
@@ -32,11 +37,16 @@ def current_onboarding_failures():
     This only shows the failures, so if none have failed or failures have been deleted, this will return 0.
     Metric labels are the failure reason.
     """
-    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_failure_count", "Device Onboarding Failures", labels=["failure_code"])
+    results_gauges = GaugeMetricFamily(
+        f"{METRICS_PREFIX}onboardtask_failure_count", "Device Onboarding Failures", labels=["failure_code"]
+    )
 
     for failure_choice in OnboardingFailChoices.CHOICES:
-        results_gauges.add_metric(labels=[failure_choice[0]], value=OnboardingTask.objects.filter(failed_reason=failure_choice[0]).count())
-        
+        results_gauges.add_metric(
+            labels=[failure_choice[0]], value=OnboardingTask.objects.filter(failed_reason=failure_choice[0]).count()
+        )
+
     yield results_gauges
+
 
 metrics = [current_onboarding_results, current_onboarding_failures]

--- a/nautobot_device_onboarding/metrics.py
+++ b/nautobot_device_onboarding/metrics.py
@@ -9,12 +9,16 @@ from nautobot_device_onboarding.models import OnboardingTask, OnboardingDevice
 
 METRICS_PREFIX = "deviceonboarding_"
 
+"""Used in the worker to keep track of total onboarding tasks.
+"""
 onboardingtask_results_counter = Counter(
     name="onboardingtask_results_total", documentation="Count of results for Onboarding Task", labelnames=("status",)
 )
 
 def current_onboarding_results():
-    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_results_count", "Device Onboarding Task Results", labels=["name"])
+    """Creates a gauge metric for Onboarding Task Results.
+    """
+    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_results_count", "Device Onboarding Task Results", labels=["status"])
     
     results_gauges.add_metric(labels=["total"],value=OnboardingTask.objects.count())
     for status_choice in OnboardingStatusChoices.CHOICES:
@@ -23,7 +27,12 @@ def current_onboarding_results():
     yield results_gauges
 
 def current_onboarding_failures():
-    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_failure_count", "Device Onboarding Failures", labels=["name"])
+    """Creates a gauge metric for Onboarding Task failures.
+
+    This only shows the failures, so if none have failed or failures have been deleted, this will return 0.
+    Metric labels are the failure reason.
+    """
+    results_gauges = GaugeMetricFamily(f"{METRICS_PREFIX}onboardtask_failure_count", "Device Onboarding Failures", labels=["failure_code"])
 
     for failure_choice in OnboardingFailChoices.CHOICES:
         results_gauges.add_metric(labels=[failure_choice[0]], value=OnboardingTask.objects.filter(failed_reason=failure_choice[0]).count())


### PR DESCRIPTION
Addresses Issue #86 
Closes #86 

Adds metrics for OnboardingTask status and failure reasons. 

Added as a gauge because users can delete results. 

Metrics: 
```
# HELP deviceonboarding_onboardtask_results_count Device Onboarding Task Results
# TYPE deviceonboarding_onboardtask_results_count gauge
deviceonboarding_onboardtask_results_count{name="total"} 2.0
deviceonboarding_onboardtask_results_count{name="failed"} 0.0
deviceonboarding_onboardtask_results_count{name="pending"} 0.0
deviceonboarding_onboardtask_results_count{name="running"} 0.0
deviceonboarding_onboardtask_results_count{name="succeeded"} 2.0
deviceonboarding_onboardtask_results_count{name="skipped"} 0.0
# HELP deviceonboarding_onboardtask_failure_count Device Onboarding Failures
# TYPE deviceonboarding_onboardtask_failure_count gauge
deviceonboarding_onboardtask_failure_count{name="fail-login"} 0.0
deviceonboarding_onboardtask_failure_count{name="fail-config"} 0.0
deviceonboarding_onboardtask_failure_count{name="fail-connect"} 0.0
deviceonboarding_onboardtask_failure_count{name="fail-execute"} 0.0
deviceonboarding_onboardtask_failure_count{name="fail-general"} 0.0
deviceonboarding_onboardtask_failure_count{name="fail-dns"} 0.0
```