### PR TITLE
Fix custom field test in test_nautobot_keeper

### DIFF
--- a/nautobot_device_onboarding/tests/test_nautobot_keeper.py
+++ b/nautobot_device_onboarding/tests/test_nautobot_keeper.py
@@ -542,7 +542,7 @@ class NautobotKeeperTestCase(TestCase):
         device = Device.objects.get(name="sw1")
 
         self.assertEqual(device.cf["cf_device"], False)
-        self.assertEqual("cf_device_null" in device.cf, False)
+        self.assertEqual(device.cf["cf_device_null"], None)
         self.assertEqual(device.platform.cf["cf_platform"], True)
         self.assertEqual(device.device_type.cf["cf_devicetype"], 5)
         self.assertEqual(device.device_role.cf["cf_devicerole"], 10)

--- a/nautobot_device_onboarding/tests/test_nautobot_keeper.py
+++ b/nautobot_device_onboarding/tests/test_nautobot_keeper.py
@@ -542,7 +542,7 @@ class NautobotKeeperTestCase(TestCase):
         device = Device.objects.get(name="sw1")
 
         self.assertEqual(device.cf["cf_device"], False)
-        self.assertEqual(device.cf["cf_device_null"], None)
+        self.assertEqual(device.cf.get("cf_device_null"), None)
         self.assertEqual(device.platform.cf["cf_platform"], True)
         self.assertEqual(device.device_type.cf["cf_devicetype"], 5)
         self.assertEqual(device.device_role.cf["cf_devicerole"], 10)


### PR DESCRIPTION
Fixes a test in test_nautobot_keeper. Custom field is present but set to None instead of not being present at all. 