### PR TITLE
Fix error if Serial # is only numbers.

### DIFF
--- a/nautobot_device_onboarding/command_mappers/cisco_ios.yml
+++ b/nautobot_device_onboarding/command_mappers/cisco_ios.yml
@@ -11,6 +11,7 @@ sync_devices:
         parser: "textfsm"
         jpath: "[*].serial[]"
         post_processor: "{{ obj | unique | first }}"
+        iterable_type: "str"
   device_type:
     commands:
       - command: "show version"
@@ -45,6 +46,7 @@ sync_network_data:
         parser: "textfsm"
         jpath: "[*].serial[]"
         post_processor: "{{ obj | unique | first }}"
+        iterable_type: "str"
   interfaces:
     root_key: true
     commands:

--- a/nautobot_device_onboarding/nornir_plays/schemas.py
+++ b/nautobot_device_onboarding/nornir_plays/schemas.py
@@ -11,7 +11,7 @@ def sync_devices_schema(json_schema=True):
             "required": ["hostname", "serial", "device_type", "mgmt_interface", "platform", "network_driver"],
             "properties": {
                 "hostname": {"type": "string", "description": "Hostname of the network device"},
-                "serial": {"type": "string", "description": "Serial number of the network device"},
+                "serial": {"type": ["string", "integer"], "description": "Serial number of the network device"},
                 "device_type": {"type": ["string", "integer"], "description": "Type of the network device"},
                 "mgmt_interface": {"type": "string", "description": "Management interface of the network device"},
                 "mask_length": {
@@ -112,7 +112,7 @@ NETWORK_DEVICES_SCHEMA = {
     "required": ["serial", "hostname", "device_type", "mgmt_interface", "mask_length"],
     "properties": {
         "serial": {
-            "type": "string",
+            "type": ["string", "integer"],
             "description": "Serial number of the network device",
             "minItems": 1,
         },

--- a/nautobot_device_onboarding/nornir_plays/schemas.py
+++ b/nautobot_device_onboarding/nornir_plays/schemas.py
@@ -130,7 +130,7 @@ NETWORK_DATA_SCHEMA = {
     "required": ["serial", "interfaces"],
     "properties": {
         "serial": {
-            "type": "string",
+            "type": ["string", "integer"],
             "description": "Serial number of the network device",
             "minItems": 1,
         },


### PR DESCRIPTION
Found that after fixes were done for device types that only had integers I ran into the error again but it was for a serial # that only had integers. I copied what was done for the fix for device type.