### PR TITLE
update to fix mtu int error

### DIFF
--- a/changes/238.fixed
+++ b/changes/238.fixed
@@ -1,0 +1,1 @@
+Added a fix for mtu as an integer rather than a string. 

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -31,9 +31,7 @@ class FilteredNautobotAdapter(NautobotAdapter):
     def _load_objects(self, diffsync_model):  # pylint: disable=protected-access
         """Given a diffsync model class, load a list of models from the database and return them."""
         parameter_names = self._get_parameter_names(diffsync_model)
-        for (
-            database_object
-        ) in diffsync_model._get_queryset(  # pylint: disable=protected-access
+        for database_object in diffsync_model._get_queryset(  # pylint: disable=protected-access
             adapter=self
         ):
             self._load_single_object(database_object, diffsync_model, parameter_names)
@@ -45,17 +43,11 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
     device = sync_network_data_models.SyncNetworkDataDevice
     interface = sync_network_data_models.SyncNetworkDataInterface
     ip_address = sync_network_data_models.SyncNetworkDataIPAddress
-    ipaddress_to_interface = (
-        sync_network_data_models.SyncNetworkDataIPAddressToInterface
-    )
+    ipaddress_to_interface = sync_network_data_models.SyncNetworkDataIPAddressToInterface
     vlan = sync_network_data_models.SyncNetworkDataVLAN
     vrf = sync_network_data_models.SyncNetworkDataVRF
-    tagged_vlans_to_interface = (
-        sync_network_data_models.SyncNetworkDataTaggedVlansToInterface
-    )
-    untagged_vlan_to_interface = (
-        sync_network_data_models.SyncNetworkDataUnTaggedVlanToInterface
-    )
+    tagged_vlans_to_interface = sync_network_data_models.SyncNetworkDataTaggedVlansToInterface
+    untagged_vlan_to_interface = sync_network_data_models.SyncNetworkDataUnTaggedVlanToInterface
     lag_to_interface = sync_network_data_models.SyncNetworkDataLagToInterface
     vrf_to_interface = sync_network_data_models.SyncNetworkDataVrfToInterface
     cable = sync_network_data_models.SyncNetworkDataCable
@@ -111,9 +103,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
                     if ip_address:
                         ip_address_hosts.add(ip_address["ip_address"])
         if "" in ip_address_hosts:
-            ip_address_hosts.remove(
-                ""
-            )  # do not attempt to filter ip addresses with empty strings
+            ip_address_hosts.remove("")  # do not attempt to filter ip addresses with empty strings
         for ip_address in IPAddress.objects.filter(
             host__in=ip_address_hosts,
             parent__namespace__name=self.job.namespace.name,
@@ -174,9 +164,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
                 name=interface.name,
                 tagged_vlans=tagged_vlans,
             )
-            network_tagged_vlans_to_interface.model_flags = (
-                DiffSyncModelFlags.SKIP_UNMATCHED_DST
-            )
+            network_tagged_vlans_to_interface.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
             self.add(network_tagged_vlans_to_interface)
 
     def load_untagged_vlan_to_interface(self):
@@ -197,9 +185,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
                 name=interface.name,
                 untagged_vlan=untagged_vlan,
             )
-            network_untagged_vlan_to_interface.model_flags = (
-                DiffSyncModelFlags.SKIP_UNMATCHED_DST
-            )
+            network_untagged_vlan_to_interface.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
             self.add(network_untagged_vlan_to_interface)
 
     def load_lag_to_interface(self):
@@ -264,10 +250,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
         """
         for device in self.job.devices_to_load:
             for cable in device.get_cables():
-                if (
-                    cable.termination_b.device.name == ""
-                    or cable.termination_a.device.name == ""
-                ):
+                if cable.termination_b.device.name == "" or cable.termination_a.device.name == "":
                     self.job.logger.warning(
                         f"Device attached to a cable is missing a name. Devices must have a name to utilize cable onboarding. "
                         f"Skipping Cable: {cable}"
@@ -349,21 +332,15 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
         This method only runs if data was changed.
         """
         if self.job.debug:
-            self.job.logger.debug(
-                "Sync Complete method called, checking for missing primary ip addresses..."
-            )
-        for (
-            device
-        ) in self.job.devices_to_load.all():  # refresh queryset after sync is complete
+            self.job.logger.debug("Sync Complete method called, checking for missing primary ip addresses...")
+        for device in self.job.devices_to_load.all():  # refresh queryset after sync is complete
             if not device.primary_ip:
                 ip_address = ""
                 try:
                     ip_address = IPAddress.objects.get(id=self.primary_ips[device.id])
                     device.primary_ip4 = ip_address
                     device.validated_save()
-                    self.job.logger.info(
-                        f"Assigning {ip_address} as primary IP Address for Device: {device.name}"
-                    )
+                    self.job.logger.info(f"Assigning {ip_address} as primary IP Address for Device: {device.name}")
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     self.job.logger.error(
                         f"Unable to set Primary IP for {device.name}, {err.args}. "
@@ -371,9 +348,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
                     )
                 if ip_address:
                     try:
-                        interface = Interface.objects.get(
-                            device=device, ip_addresses__in=[ip_address]
-                        )
+                        interface = Interface.objects.get(device=device, ip_addresses__in=[ip_address])
                         interface.mgmt_only = True
                         interface.validated_save()
                         self.job.logger.info(
@@ -409,17 +384,11 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
     device = sync_network_data_models.SyncNetworkDataDevice
     interface = sync_network_data_models.SyncNetworkDataInterface
     ip_address = sync_network_data_models.SyncNetworkDataIPAddress
-    ipaddress_to_interface = (
-        sync_network_data_models.SyncNetworkDataIPAddressToInterface
-    )
+    ipaddress_to_interface = sync_network_data_models.SyncNetworkDataIPAddressToInterface
     vlan = sync_network_data_models.SyncNetworkDataVLAN
     vrf = sync_network_data_models.SyncNetworkDataVRF
-    tagged_vlans_to_interface = (
-        sync_network_data_models.SyncNetworkDataTaggedVlansToInterface
-    )
-    untagged_vlan_to_interface = (
-        sync_network_data_models.SyncNetworkDataUnTaggedVlanToInterface
-    )
+    tagged_vlans_to_interface = sync_network_data_models.SyncNetworkDataTaggedVlansToInterface
+    untagged_vlan_to_interface = sync_network_data_models.SyncNetworkDataUnTaggedVlanToInterface
     lag_to_interface = sync_network_data_models.SyncNetworkDataLagToInterface
     vrf_to_interface = sync_network_data_models.SyncNetworkDataVrfToInterface
     cable = sync_network_data_models.SyncNetworkDataCable
@@ -457,10 +426,8 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
         for hostname in failed_devices:
             del device_data[hostname]
 
-        device_queryset, devices_with_errors = (
-            diffsync_utils.generate_device_queryset_from_command_getter_result(
-                job=self.job, command_getter_result=device_data
-            )
+        device_queryset, devices_with_errors = diffsync_utils.generate_device_queryset_from_command_getter_result(
+            job=self.job, command_getter_result=device_data
         )
 
         # remove devices that have errors found while creating the queryset from the command getter results
@@ -476,9 +443,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
 
     def _handle_general_load_exception(self, error, hostname, data, model_type):
         """If a diffsync model fails to load, log the error."""
-        self.job.logger.error(
-            f"Failed to load {model_type} model for {hostname}. {error}, {error.args}"
-        )
+        self.job.logger.error(f"Failed to load {model_type} model for {hostname}. {error}, {error.args}")
         if self.job.debug:
             self.job.logger.debug(f"HOSTNAME: {hostname}, DATA: {data}")
 
@@ -492,9 +457,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
         # verify data returned is a dict
         data_type_check = diffsync_utils.check_data_type(result)
         if self.job.debug:
-            self.job.logger.debug(
-                f"CommandGetter data type check result: {data_type_check}"
-            )
+            self.job.logger.debug(f"CommandGetter data type check result: {data_type_check}")
         if data_type_check:
             self._handle_failed_devices(device_data=result)
         else:
@@ -521,15 +484,11 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                 )
                 self.add(network_device)
             except Exception as err:  # pylint: disable=broad-exception-caught
-                self._handle_general_load_exception(
-                    error=err, hostname=hostname, data=device_data, model_type="device"
-                )
+                self._handle_general_load_exception(error=err, hostname=hostname, data=device_data, model_type="device")
                 continue
             # for interface in device_data["interfaces"]:
             for interface_name, interface_data in device_data["interfaces"].items():
-                network_interface = self.load_interface(
-                    hostname, interface_name, interface_data
-                )
+                network_interface = self.load_interface(hostname, interface_name, interface_data)
                 network_device.add_child(network_interface)
 
     # def _get_vlan_name(self, interface_data):
@@ -547,9 +506,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
             device__name=hostname,
             status__name=self.job.interface_status.name,
             type=interface_data["type"],
-            mac_address=self._process_mac_address(
-                mac_address=interface_data["mac_address"]
-            ),
+            mac_address=self._process_mac_address(mac_address=interface_data["mac_address"]),
             mtu=interface_data["mtu"] if interface_data["mtu"] else "1500",
             description=interface_data["description"],
             enabled=interface_data["link_status"],
@@ -573,13 +530,9 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
             for interface_name, interface_data in device_data["interfaces"].items():
                 if interface_data["ip_addresses"]:
                     for ip_address in interface_data["ip_addresses"]:
-                        if ip_address[
-                            "ip_address"
-                        ]:  # the ip_address and mask_length may be empty, skip these
+                        if ip_address["ip_address"]:  # the ip_address and mask_length may be empty, skip these
                             if self.job.debug:
-                                self.job.logger.debug(
-                                    f"Loading {ip_address} from {interface_name} on {hostname}"
-                                )
+                                self.job.logger.debug(f"Loading {ip_address} from {interface_name} on {hostname}")
                             try:
                                 network_ip_address = self.ip_address(
                                     adapter=self,
@@ -616,9 +569,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
         for (
             hostname,
             device_data,
-        ) in (
-            self.job.command_getter_result.items()
-        ):  # pylint: disable=too-many-nested-blocks
+        ) in self.job.command_getter_result.items():  # pylint: disable=too-many-nested-blocks
             if self.job.debug:
                 self.job.logger.debug(f"Loading Vlans from {hostname}")
             # for interface in device_data["interfaces"]:
@@ -669,9 +620,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
         for (
             hostname,
             device_data,
-        ) in (
-            self.job.command_getter_result.items()
-        ):  # pylint: disable=too-many-nested-blocks
+        ) in self.job.command_getter_result.items():  # pylint: disable=too-many-nested-blocks
             if self.job.debug:
                 self.job.logger.debug(f"Loading Vrfs from {hostname}")
             # for interface in device_data["interfaces"]:
@@ -700,27 +649,19 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
         for (
             hostname,
             device_data,
-        ) in (
-            self.job.command_getter_result.items()
-        ):  # pylint: disable=too-many-nested-blocks
+        ) in self.job.command_getter_result.items():  # pylint: disable=too-many-nested-blocks
             for interface_name, interface_data in device_data["interfaces"].items():
                 for ip_address in interface_data["ip_addresses"]:
-                    if ip_address[
-                        "ip_address"
-                    ]:  # the ip_address and mask_length may be empty, skip these
+                    if ip_address["ip_address"]:  # the ip_address and mask_length may be empty, skip these
                         try:
-                            network_ip_address_to_interface = (
-                                self.ipaddress_to_interface(
-                                    adapter=self,
-                                    interface__device__name=hostname,
-                                    interface__name=interface_name,
-                                    ip_address__host=ip_address["ip_address"],
-                                    ip_address__mask_length=(
-                                        int(ip_address["prefix_length"])
-                                        if ip_address["prefix_length"]
-                                        else None
-                                    ),
-                                )
+                            network_ip_address_to_interface = self.ipaddress_to_interface(
+                                adapter=self,
+                                interface__device__name=hostname,
+                                interface__name=interface_name,
+                                ip_address__host=ip_address["ip_address"],
+                                ip_address__mask_length=(
+                                    int(ip_address["prefix_length"]) if ip_address["prefix_length"] else None
+                                ),
                             )
                             self.add(network_ip_address_to_interface)
                         except (
@@ -762,13 +703,11 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
             # for interface in device_data["interfaces"]:
             for interface_name, interface_data in device_data["interfaces"].items():
                 try:
-                    network_untagged_vlan_to_interface = (
-                        self.untagged_vlan_to_interface(
-                            adapter=self,
-                            device__name=hostname,
-                            name=interface_name,
-                            untagged_vlan=interface_data["untagged_vlan"],
-                        )
+                    network_untagged_vlan_to_interface = self.untagged_vlan_to_interface(
+                        adapter=self,
+                        device__name=hostname,
+                        name=interface_name,
+                        untagged_vlan=interface_data["untagged_vlan"],
                     )
                     self.add(network_untagged_vlan_to_interface)
                 except Exception as err:  # pylint: disable=broad-exception-caught
@@ -790,9 +729,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                         adapter=self,
                         device__name=hostname,
                         name=interface_name,
-                        lag__interface__name=(
-                            interface_data["lag"] if interface_data["lag"] else ""
-                        ),
+                        lag__interface__name=(interface_data["lag"] if interface_data["lag"] else ""),
                     )
                     self.add(network_lag_to_interface)
                 except Exception as err:  # pylint: disable=broad-exception-caught
@@ -830,9 +767,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
         """Load cables into the Diffsync store."""
         for hostname, device_data in self.job.command_getter_result.items():
             if "cables" not in device_data:
-                self.job.logger.warning(
-                    f"No cable data found for {hostname}. Skipping cable load."
-                )
+                self.job.logger.warning(f"No cable data found for {hostname}. Skipping cable load.")
                 return
             if self.job.debug:
                 self.job.logger.debug(f"Loading Cables from {hostname}")
@@ -843,9 +778,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
             try:
                 for neighbor_data in device_data["cables"]:
                     try:
-                        local_interface = canonical_interface_name(
-                            neighbor_data["local_interface"]
-                        )
+                        local_interface = canonical_interface_name(neighbor_data["local_interface"])
                     except KeyError as error:
                         error.args = error.args + "Local interface is missing a name."
                         self._handle_general_load_exception(
@@ -857,9 +790,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                         continue
 
                     try:
-                        remote_interface = canonical_interface_name(
-                            neighbor_data["remote_interface"]
-                        )
+                        remote_interface = canonical_interface_name(neighbor_data["remote_interface"])
                     except KeyError as error:
                         error.args = error.args + "Remote interface is missing a name."
                         self._handle_general_load_exception(

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -31,9 +31,11 @@ class FilteredNautobotAdapter(NautobotAdapter):
     def _load_objects(self, diffsync_model):  # pylint: disable=protected-access
         """Given a diffsync model class, load a list of models from the database and return them."""
         parameter_names = self._get_parameter_names(diffsync_model)
-        for database_object in diffsync_model._get_queryset(
+        for (
+            database_object
+        ) in diffsync_model._get_queryset(  # pylint: disable=protected-access
             adapter=self
-        ):  # pylint: disable=protected-access
+        ):
             self._load_single_object(database_object, diffsync_model, parameter_names)
 
 
@@ -561,12 +563,10 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
 
     def load_ip_addresses(self):
         """Load IP addresses into the DiffSync store."""
-        for (
+        for (  # pylint: disable=too-many-nested-blocks
             hostname,
             device_data,
-        ) in (
-            self.job.command_getter_result.items()
-        ):  # pylint: disable=too-many-nested-blocks
+        ) in self.job.command_getter_result.items():
             if self.job.debug:
                 self.job.logger.debug(f"Loading IP Addresses from {hostname}")
             # for interface in device_data["interfaces"]:
@@ -597,8 +597,8 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                                 )
                                 continue
                             except (
-                                Exception
-                            ) as err:  # pylint: disable=broad-exception-caught
+                                Exception  # pylint: disable=broad-exception-caught
+                            ) as err:
                                 self._handle_general_load_exception(
                                     error=err,
                                     hostname=hostname,
@@ -724,8 +724,8 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                             )
                             self.add(network_ip_address_to_interface)
                         except (
-                            Exception
-                        ) as err:  # pylint: disable=broad-exception-caught
+                            Exception  # pylint: disable=broad-exception-caught
+                        ) as err:
                             self._handle_general_load_exception(
                                 error=err,
                                 hostname=hostname,


### PR DESCRIPTION
The fix added in is lines 93-98. The rest is formatting. 

Discovered when building a fresh instance from develop, using SSoT 3.1.0 and dependencies, a Pydantic error was raised when running the sync network data job on the interface field MTU. Added in an override to force a string on this field. 

