### PR TITLE
update interface load method exception handling

### DIFF
--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -488,9 +488,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                 continue
             for interface_name, interface_data in device_data["interfaces"].items():
                 try:
-                    network_interface = self.load_interface(
-                        hostname, interface_name, interface_data
-                    )
+                    network_interface = self.load_interface(hostname, interface_name, interface_data)
                     network_device.add_child(network_interface)
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     self._handle_general_load_exception(

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -486,10 +486,20 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
             except Exception as err:  # pylint: disable=broad-exception-caught
                 self._handle_general_load_exception(error=err, hostname=hostname, data=device_data, model_type="device")
                 continue
-            # for interface in device_data["interfaces"]:
             for interface_name, interface_data in device_data["interfaces"].items():
-                network_interface = self.load_interface(hostname, interface_name, interface_data)
-                network_device.add_child(network_interface)
+                try:
+                    network_interface = self.load_interface(
+                        hostname, interface_name, interface_data
+                    )
+                    network_device.add_child(network_interface)
+                except Exception as err:  # pylint: disable=broad-exception-caught
+                    self._handle_general_load_exception(
+                        error=err,
+                        hostname=hostname,
+                        data=device_data,
+                        model_type="interface",
+                    )
+                    continue
 
     # def _get_vlan_name(self, interface_data):
     #     """Given interface data returned from a device, process and return the vlan name."""


### PR DESCRIPTION
Add general exception handling when loading interfaces into a DiffSync model. This is used as a last resort catch for invalid data that may have slipped through schema validation or other checks.