### PR TITLE
Fix typos on docs

### DIFF
--- a/changes/286.housekeeping
+++ b/changes/286.housekeeping
@@ -1,1 +1,1 @@
-Fixed types on app overview file
+Fixed typos on app overview file

--- a/changes/286.housekeeping
+++ b/changes/286.housekeeping
@@ -1,0 +1,1 @@
+Fixed types on app overview file

--- a/docs/user/app_overview.md
+++ b/docs/user/app_overview.md
@@ -9,7 +9,7 @@ This [Nautobot](https://github.com/nautobot/nautobot) App allows to easily onboa
 
 ## Description/Overview
 
-This section descibes the new implementaiton (SSoT Implementation) and the Original implementation.
+This section describes the new implementation (SSoT Implementation) and the original implementation.
 
 ### New SSoT Implementation
 


### PR DESCRIPTION
Fix typos on docs on the app overview file