### PR TITLE
Fixes SSH public key auth, misc document clean-up

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -152,6 +152,8 @@ PLUGINS_CONFIG = {
                 "extras": {
                     "fast_cli": False,
                     "read_timeout_override": 30,
+                    "use_keys": True,
+                    "key_file": "/source/.ssh_test/id_rsa",
                 },
             },
         },

--- a/docs/user/app_getting_started.md
+++ b/docs/user/app_getting_started.md
@@ -64,11 +64,7 @@ The new SSoT based jobs each use their own Nornir inventories.
 
 ### Onboarding a Device
 
-Navigate to the Device Onboarding Job: Jobs > Perform Device Onboarding (original).
-
-or
-
-Navigate to the SSoT dashboard and run `Sync Devices` to get basic device and information onboarding, followed by `Sync Network Data` to add additional details from the network to these devices. E.g. Interfaces, IPs, VRFs, VLANs.
+Navigate to the `Jobs` page from the nautobot navigation bar. Run `Sync Devices From Network` to get basic device and information onboarding, followed by `Sync Network Data From Network` to add additional details from the network to these devices. E.g. Interfaces, IPs, VRFs, VLANs.
 
 ## What are the next steps?
 

--- a/docs/user/app_use_cases.md
+++ b/docs/user/app_use_cases.md
@@ -107,7 +107,7 @@ PLUGINS_CONFIG = {
             "netmiko": {
                 "extras": {
                     "use_keys": True,
-                    "key_file": "/root/.ssh/id_rsa.pub",
+                    "key_file": "/root/.ssh/id_rsa",
                     "disabled_algorithms": {"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]},
                 },
             },
@@ -116,7 +116,7 @@ PLUGINS_CONFIG = {
 }
 ```
 
-3. Make a secrets group in Nautobot which still had all the elements (username and password), where the username is accurate, a bogus password can be used as its ignored by the backend processing. For example, set the password to the username secret since its ignore.
+3. Make a secrets group in Nautobot which has the accurate `username` to use along with the key specified in configuration above.
 
 4. Run the jobs and ssh public key authentication will be used.
 

--- a/nautobot_device_onboarding/nornir_plays/inventory_creator.py
+++ b/nautobot_device_onboarding/nornir_plays/inventory_creator.py
@@ -1,14 +1,16 @@
 """Inventory Creator and Helpers."""
 
+from typing import Dict, Tuple, Union
+
 from netmiko import SSHDetect
 from nornir.core.inventory import ConnectionOptions, Host
 
 from nautobot_device_onboarding.constants import NETMIKO_EXTRAS
 
 
-def guess_netmiko_device_type(hostname, username, password, port):
+def guess_netmiko_device_type(hostname: str, username: str, password: str, port: str) -> Tuple[str, Union[Exception, None]]:
     """Guess the device type of host, based on Netmiko."""
-    netmiko_optional_args = {"port": port}
+    netmiko_optional_args = {"port": port, **NETMIKO_EXTRAS}
     guessed_device_type = None
 
     remote_device = {
@@ -30,7 +32,7 @@ def guess_netmiko_device_type(hostname, username, password, port):
     return guessed_device_type, guessed_exc
 
 
-def _set_inventory(host_ip, platform, port, username, password):
+def _set_inventory(host_ip: str, platform: str, port: str, username: str, password: str) -> Tuple[Dict, Union[Exception, None]]:
     """Construct Nornir Inventory."""
     inv = {}
     if platform:


### PR DESCRIPTION
# What this does 

This PR
* fixes code logic to make ssh public key authorization possible.
* makes small tweak to the document

* Fixes #293 
* Addresses one-bullet point of #291 - not 100% sure the best place to address the rest. Kinda seems like some of it is a core nautobot fix to expose filters to the user that are being applied when searching for a role/location/etc.

# Testing

1. Made the following changes to my nautobot config:

```diff
+++ b/development/nautobot_config.py
@@ -152,6 +152,8 @@ PLUGINS_CONFIG = {
                 "extras": {
                     "fast_cli": False,
                     "read_timeout_override": 30,
+                    "use_keys": True,
+                    "key_file": "/source/.ssh_test/id_rsa",
                 },
             },
         },
```

2. Created an ssh rsa key at `.ssh_test/id_rsa` in this repo
2. Spun-up a containerlabs instance of an arista ceos and enabled SSH public key auth using that public key
3. Created a secretsgroup where i just specified the `username` (i also tried setting the password to a random value as suggested in the docs, but that seemed kinda pointless so I modified the docs accordingly)
4. Ran a job against the arista device and confirmed that login was successful