### PR TITLE
add missing 'adapter' from logging message

### DIFF
--- a/changes/306.fixed
+++ b/changes/306.fixed
@@ -1,0 +1,1 @@
+Fixed error with logging message in SyncNetworkDataIPAddress.update()

--- a/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
+++ b/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
@@ -161,7 +161,7 @@ class SyncNetworkDataIPAddress(DiffSyncModel):
         try:
             ip_address = IPAddress.objects.get(host=self.host, parent__namespace=self.adapter.job.namespace)
         except ObjectDoesNotExist as err:
-            self.job.logger.error(f"{self} failed to update, {err}")
+            self.adapter.job.logger.error(f"{self} failed to update, {err}")
         if attrs.get("mask_length"):
             ip_address.mask_length = attrs["mask_length"]
         if attrs.get("status__name"):
@@ -171,7 +171,7 @@ class SyncNetworkDataIPAddress(DiffSyncModel):
         try:
             ip_address.validated_save()
         except ValidationError as err:
-            self.job.logger.error(f"{self} failed to update, {err}")
+            self.adapter.job.logger.error(f"{self} failed to update, {err}")
 
         return super().update(attrs)
 


### PR DESCRIPTION
Fix bug in two logging messages that cause the job to crash if hit. The log messages are only triggered when one of the attributes on the ip_address model is updated and the update fails `validated_save`.


