### PR TITLE
Fixed app startup crashing nautobot during startup in some cases.

### DIFF
--- a/changes/320.fixed
+++ b/changes/320.fixed
@@ -1,0 +1,1 @@
+Fixed app startup crashing nautobot during startup in some cases.

--- a/nautobot_device_onboarding/constants.py
+++ b/nautobot_device_onboarding/constants.py
@@ -1,7 +1,6 @@
 """Constants for nautobot_device_onboarding app."""
 
 from django.conf import settings
-from nautobot.dcim.utils import get_all_network_driver_mappings
 
 NETMIKO_EXTRAS = (
     settings.PLUGINS_CONFIG.get("nautobot_plugin_nornir", {})
@@ -22,9 +21,6 @@ NETMIKO_TO_NAPALM_STATIC = {
     "cisco_xr": "iosxr",
 }
 
-
-# This is used in the new SSoT based jobs.
-SUPPORTED_NETWORK_DRIVERS = list(get_all_network_driver_mappings().keys())
 
 # This is used in the new SSoT based jobs. Soon PYATS should be supported.
 SUPPORTED_COMMAND_PARSERS = ["textfsm", "ttp"]

--- a/nautobot_device_onboarding/nornir_plays/command_getter.py
+++ b/nautobot_device_onboarding/nornir_plays/command_getter.py
@@ -20,7 +20,7 @@ from nornir_netmiko.tasks import netmiko_send_command
 from ntc_templates.parse import parse_output
 from ttp import ttp
 
-from nautobot_device_onboarding.constants import SUPPORTED_COMMAND_PARSERS, SUPPORTED_NETWORK_DRIVERS
+from nautobot_device_onboarding.constants import SUPPORTED_COMMAND_PARSERS
 from nautobot_device_onboarding.nornir_plays.empty_inventory import EmptyInventory
 from nautobot_device_onboarding.nornir_plays.inventory_creator import _set_inventory
 from nautobot_device_onboarding.nornir_plays.logger import NornirLogger
@@ -112,7 +112,7 @@ def netmiko_send_commands(
     """Run commands specified in PLATFORM_COMMAND_MAP."""
     if not task.host.platform:
         return Result(host=task.host, result=f"{task.host.name} has no platform set.", failed=True)
-    if task.host.platform not in SUPPORTED_NETWORK_DRIVERS or not "cisco_wlc_ssh":
+    if task.host.platform not in get_all_network_driver_mappings().keys() or not "cisco_wlc_ssh":
         return Result(host=task.host, result=f"{task.host.name} has a unsupported platform set.", failed=True)
     if not command_getter_yaml_data[task.host.platform].get(command_getter_job):
         return Result(
@@ -354,7 +354,7 @@ def sync_network_data_command_getter(job_result, log_level, kwargs):
                     "queryset": qs,
                     "defaults": {
                         "platform_parsing_info": add_platform_parsing_info(),
-                        "network_driver_mappings": SUPPORTED_NETWORK_DRIVERS,
+                        "network_driver_mappings": list(get_all_network_driver_mappings().keys()),
                         "sync_vlans": kwargs["sync_vlans"],
                         "sync_vrfs": kwargs["sync_vrfs"],
                         "sync_cables": kwargs["sync_cables"],

--- a/nautobot_device_onboarding/nornir_plays/empty_inventory.py
+++ b/nautobot_device_onboarding/nornir_plays/empty_inventory.py
@@ -1,8 +1,8 @@
 """Empty Nornir Inventory Plugin."""
 
+from nautobot.dcim.utils import get_all_network_driver_mappings
 from nornir.core.inventory import Defaults, Groups, Hosts, Inventory
 
-from nautobot_device_onboarding.constants import SUPPORTED_NETWORK_DRIVERS
 from nautobot_device_onboarding.nornir_plays.transform import add_platform_parsing_info
 
 
@@ -15,7 +15,7 @@ class EmptyInventory:  # pylint: disable=too-few-public-methods
         defaults = Defaults(
             data={
                 "platform_parsing_info": add_platform_parsing_info(),
-                "network_driver_mappings": SUPPORTED_NETWORK_DRIVERS,
+                "network_driver_mappings": list(get_all_network_driver_mappings().keys()),
             }
         )
         groups = Groups()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #320

## What's Changed

Nautobot core v2.4.3 upgraded to constance version 4. Constance v4 changes their database `value` field from a `PickledObjectField` to a `TextField` where they store JSON data. When we try to access constance before their `0003` data migration runs it raises a `JSONDecodeError` because the data has not yet been migrated from pickle data to JSON data. Device onboarding accesses constance at import time and prevents the database migrations from running at all.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
