### PR TITLE
Fix ingesting cable terminations of circuit types

### DIFF
--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -5,6 +5,7 @@ import datetime
 import diffsync
 from diffsync.enum import DiffSyncModelFlags
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from nautobot.dcim.models import Interface
 from nautobot.ipam.models import VLAN, VRF, IPAddress
@@ -249,9 +250,13 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
 
         Only cables returned by the CommandGetter job should be synced.
         """
+        dcim_interface_content_type = ContentType.objects.get_for_model(Interface)
         for device in self.job.devices_to_load:
             for cable in device.get_cables():
-                if cable.termination_a.type != "dcim.interface" or cable.termination_b.type != "dcim.interface":
+                if (
+                    cable.termination_a_type != dcim_interface_content_type
+                    or cable.termination_b_type != dcim_interface_content_type
+                ):
                     self.job.logger.warning(
                         f"Skipping Cable: {cable}. Only cables with interface terminations are supported."
                     )

--- a/nautobot_device_onboarding/tests/utils.py
+++ b/nautobot_device_onboarding/tests/utils.py
@@ -160,7 +160,7 @@ def sync_network_data_ensure_required_nautobot_objects():
         location=location,
     )
 
-    cable_to_circuit_1 = Cable.objects.get_or_create(
+    cable_to_circuit_1, _ = Cable.objects.get_or_create(
         termination_a_type=ContentType.objects.get_for_model(Interface),
         termination_a_id=interface_4.id,
         termination_b_type=ContentType.objects.get_for_model(CircuitTermination),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #326


## What's Changed

Fixed accessing a cable's termination type.
Added tests to ensure we are skipping cables with termination type of circuit. 

## To Do
none
