### PR TITLE
added support for multiple IPs on juniper interface

### DIFF
--- a/changes/346.fixed
+++ b/changes/346.fixed
@@ -1,0 +1,1 @@
+Fixed Juniper IP addresses not syncing secondary IP addresses.

--- a/nautobot_device_onboarding/jinja_filters.py
+++ b/nautobot_device_onboarding/jinja_filters.py
@@ -4,6 +4,7 @@ import logging
 from itertools import chain
 
 from django_jinja import library
+from netutils.ip import is_ip
 from netutils.vlan import vlanconfig_to_list
 
 from nautobot_device_onboarding.constants import INTERFACE_TYPE_MAP_STATIC
@@ -174,11 +175,27 @@ def parse_junos_ip_address(item):
     """
     if isinstance(item, list) and len(item) > 0:
         if item[0]["prefix_length"] and item[0]["ip_address"]:
-            return [
-                {"prefix_length": item[0]["prefix_length"][0].split("/")[-1], "ip_address": item[0]["ip_address"][0]}
-            ]
+            result = []
+            for i in range(len(item[0]["ip_address"])):
+                prefix = item[0]["prefix_length"][i].split("/")[-1]
+                result.append(
+                    {
+                        "prefix_length": prefix,
+                        "ip_address": item[0]["ip_address"][i],
+                    }
+                )
+            return result
         if not item[0]["prefix_length"] and item[0]["ip_address"]:
-            return [{"prefix_length": 32, "ip_address": item[0]["ip_address"][0]}]
+            result = []
+            for i in range(len(item[0]["ip_address"])):
+                if is_ip(item[0]["ip_address"][i]):
+                    result.append(
+                        {
+                            "prefix_length": 32,
+                            "ip_address": item[0]["ip_address"][i],
+                        }
+                    )
+            return result
     return []
 
 

--- a/nautobot_device_onboarding/tests/test_formatter.py
+++ b/nautobot_device_onboarding/tests/test_formatter.py
@@ -547,7 +547,7 @@ class TestFormatterSyncNetworkDataNoOptions(unittest.TestCase):
                                 command_outputs,
                                 job_debug=False,
                             )
-                            self.assertEqual(expected_parsed_result, actual_result)
+                            self.assertCountEqual(expected_parsed_result, actual_result)
 
 
 class TestFormatterSyncNetworkDataWithVrfs(unittest.TestCase):
@@ -615,7 +615,7 @@ class TestFormatterSyncNetworkDataWithVrfs(unittest.TestCase):
                                 command_outputs,
                                 job_debug=False,
                             )
-                            self.assertEqual(expected_parsed_result, actual_result)
+                            self.assertCountEqual(expected_parsed_result, actual_result)
 
 
 class TestFormatterSyncNetworkDataWithVlans(unittest.TestCase):
@@ -683,7 +683,7 @@ class TestFormatterSyncNetworkDataWithVlans(unittest.TestCase):
                                 command_outputs,
                                 job_debug=False,
                             )
-                            self.assertEqual(expected_parsed_result, actual_result)
+                            self.assertCountEqual(expected_parsed_result, actual_result)
 
 
 @unittest.skip(reason="Todo test sync network data with all options.")

--- a/nautobot_device_onboarding/tests/test_jinja_filters.py
+++ b/nautobot_device_onboarding/tests/test_jinja_filters.py
@@ -238,15 +238,14 @@ class TestJinjaFilters(unittest.TestCase):
         expected = [{"prefix_length": "31", "ip_address": "10.65.229.106"}]
         self.assertEqual(parse_junos_ip_address(data), expected)
 
-    @unittest.skip("Need to correct assert used for list of dictionaries.")
     def test_parse_junos_ip_address_values_as_list_multiple(self):
         """Parse Junos IP and destination prefix."""
         data = [{"prefix_length": ["10.65.133.0/29", "10.65.133.0/29"], "ip_address": ["10.65.133.1", "10.65.133.3"]}]
         expected = [
             {"prefix_length": "29", "ip_address": "10.65.133.1"},
-            {"ip_address": "10.65.133.3", "prefix_length": "29"},
+            {"prefix_length": "29", "ip_address": "10.65.133.3"},
         ]
-        self.assertEqual(parse_junos_ip_address(data), expected)
+        self.assertCountEqual(parse_junos_ip_address(data), expected)
 
     def test_parse_junos_ip_address_values_as_empty_list(self):
         """Parse Junos IP and destination prefix."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #346 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
Fixes bug where multiple IPs on a juniper interface were not being parsed. New functionality adds support for multiple IPs. 

`In [4]: item = [{'prefix_length': ['172.22.0.0/28', '172.22.0.0/28'], 'ip_address': ['172.22.0
   ...: .1', '127.22.0.2']}]

In [5]: parse_junos_ip_address(item)
Out[5]: 
[{'prefix_length': '28', 'ip_address': '172.22.0.1'},
 {'prefix_length': '28', 'ip_address': '127.22.0.2'}]
`
## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
