### PR TITLE
[WIP] Draft / prototype for device discovery

### DIFF
--- a/nautobot_device_onboarding/choices.py
+++ b/nautobot_device_onboarding/choices.py
@@ -1,4 +1,6 @@
 """Choices used througout the app."""
+from nautobot.core.choices import ChoiceSet
+
 
 SSOT_JOB_TO_COMMAND_CHOICE = (
     ("sync_devices", "Sync Devices"),
@@ -14,8 +16,4 @@ class AutodiscoveryProtocolTypeChoices(ChoiceSet):
 
     CHOICES = (
         (SSH, "ssh"),
-    )
-
-    AUTODISCOVERY_PORTS = (
-        (SSH, [22]),
     )

--- a/nautobot_device_onboarding/choices.py
+++ b/nautobot_device_onboarding/choices.py
@@ -5,3 +5,17 @@ SSOT_JOB_TO_COMMAND_CHOICE = (
     ("sync_network_data", "Sync Network Data"),
     ("both", "Both"),
 )
+
+
+class AutodiscoveryProtocolTypeChoices(ChoiceSet):
+    """Auto Discovery Protocol Type Choices."""
+
+    SSH = "ssh"
+
+    CHOICES = (
+        (SSH, "ssh"),
+    )
+
+    AUTODISCOVERY_PORTS = (
+        (SSH, [22]),
+    )

--- a/nautobot_device_onboarding/constants.py
+++ b/nautobot_device_onboarding/constants.py
@@ -1,6 +1,10 @@
 """Constants for nautobot_device_onboarding app."""
 
 from django.conf import settings
+from netutils.data_files.protocol_mappings import PROTOCOLS as NETUTILS_PROTOCOLS
+
+from .choices import AutodiscoveryProtocolTypeChoices
+
 
 NETMIKO_EXTRAS = (
     settings.PLUGINS_CONFIG.get("nautobot_plugin_nornir", {})
@@ -50,3 +54,7 @@ ONBOARDING_COMMAND_MAPPERS_CONTENT_IDENTIFIER = "nautobot_device_onboarding.onbo
 
 # The git repository data source folder name for custom command mappers.
 ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER = "onboarding_command_mappers"
+
+AUTODISCOVERY_PORTS = {
+    AutodiscoveryProtocolTypeChoices.SSH: [NETUTILS_PROTOCOLS["ssh"]["port_number"]],
+}


### PR DESCRIPTION
Prototype for device discovery built on-top of existing SSOT Job.

Current support is for SSH only (same as existing SSOT job), however more methods like SNMP can be added in the future if needed.

Assumptions:
- There is an implemented opinion about network discovery workflow:
  - User to specify scanned prefixes
  - For targets discovered within prefixes, kickoff regular onboarding job
  - Skip existing Nautobot Device Primary IP4s from being scanned

- Integrates with existing device onboarding
- Focuses on SSH running on 22, but can be extended for other ports and protocols
 - Crawling (CDP/LLDP) not being a priority
- Re-uses hackaton project for threading
- Does not integrate nmap/ scapy / scanners as these can be not allowed by Enterprise Security teams
- Does not store models / information about discovered endpoints
- Current support is for providing Prefix based on tags - this might need some thought process


TODO
- [ ] Tests
- [ ] Code to be finalised
- [ ] Finalise "Prefix Input" field