### PR TITLE
Fix CI to pin virtualenv module to use the build option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-version: "1.8.5"
+      - name: "Pip install virtualenv to avoid issue with virtualenv --wheel"
+        run: "~/.local/share/pypoetry/venv/bin/pip install virtualenv==20.30.0"
       - name: "Constrain Nautobot version and regenerate lock file"
         env:
           INVOKE_NAUTOBOT_DEVICE_ONBOARDING_LOCAL: "true"
@@ -160,6 +162,8 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
           poetry-version: "1.8.5"
+      - name: "Pip install virtualenv to avoid issue with virtualenv --wheel"
+        run: "~/.local/share/pypoetry/venv/bin/pip install virtualenv==20.30.0"
       - name: "Constrain Nautobot version and regenerate lock file"
         env:
           INVOKE_NAUTOBOT_DEVICE_ONBOARDING_LOCAL: "true"

--- a/changes/369.fixed
+++ b/changes/369.fixed
@@ -1,0 +1,1 @@
+Pinned virtualenv module in CI to version that supports the build option.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #368 

## What's Changed

Add a CI step to pin to a specific version of virtualenv

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
