### PR TITLE
Remove extraneous `logging.basicConfig` call

### DIFF
--- a/nautobot_device_onboarding/jinja_filters.py
+++ b/nautobot_device_onboarding/jinja_filters.py
@@ -11,7 +11,6 @@ from nautobot_device_onboarding.constants import INTERFACE_TYPE_MAP_STATIC
 
 # https://docs.nautobot.com/projects/core/en/stable/development/apps/api/platform-features/jinja2-filters/
 
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This appeared to be the root cause of a lot of annoying log noise.