### PR TITLE
Assign secondary IP-Address to Interface

### DIFF
--- a/changes/389.fixed
+++ b/changes/389.fixed
@@ -1,0 +1,3 @@
+Add role to the IP-Address model.
+Added jinja filter to parse the output of 'show ip interface'.
+Add the ability to assign a secondary IP-address to an interface.

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -120,6 +120,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
                 type=ip_address.type,
                 ip_version=ip_address.ip_version,
                 status__name=ip_address.status.name,
+                role__name=ip_address.role.name if ip_address.role else "",
             )
             try:
                 network_ip_address.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
@@ -614,6 +615,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                                     type="host",
                                     ip_version=4,
                                     status__name=self.job.ip_address_status.name,
+                                    role__name=ip_address.get("role", ""),
                                 )
                                 self.add(network_ip_address)
                             except diffsync.exceptions.ObjectAlreadyExists:

--- a/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
+++ b/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
@@ -153,7 +153,7 @@ class SyncNetworkDataIPAddress(DiffSyncModel):
             mask_length=attrs["mask_length"],
             namespace=adapter.job.namespace,
             default_ip_status=adapter.job.ip_address_status,
-            default_ip_role=Role.objects.get(name="Secondary"),
+            default_ip_role=Role.objects.get(name=""),
             default_prefix_status=adapter.job.default_prefix_status,
             job=adapter.job,
         )

--- a/nautobot_device_onboarding/jinja_filters.py
+++ b/nautobot_device_onboarding/jinja_filters.py
@@ -162,6 +162,43 @@ def get_vlan_data(item, vlan_mapping, tag_type):  # pylint: disable=too-many-ret
             ]
     return []
 
+@library.filter
+def parse_cisco_xe_show_ip_interface(item):
+
+    """Parse Cisco XE show ip interface
+
+    The first IP address is considered the primary IP address, and subsequent addresses are secondary.
+
+    Example:
+    [
+        {
+            "IP_ADDRESS": [
+                "192.168.178.240",
+                "192.168.178.120"
+            ],
+            "PREFIX_LENGTH": [
+                "24",
+                "24"
+            ],
+        }
+    ]
+
+    """
+    if isinstance(item, list) and len(item) > 0:
+        result = []
+        for interface in item:
+            for i in range(len(interface["ip_address"])):
+                if interface["ip_address"][i] and interface["prefix_length"][i]:
+                    ip = {
+                        "prefix_length": interface["prefix_length"][i],
+                        "ip_address": interface["ip_address"][i]
+                    }
+                    if i > 0:
+                        ip["role"] = "Secondary"
+                    result.append(ip)
+        return result
+    return []
+        
 
 @library.filter
 def parse_junos_ip_address(item):

--- a/nautobot_device_onboarding/utils/diffsync_utils.py
+++ b/nautobot_device_onboarding/utils/diffsync_utils.py
@@ -61,7 +61,7 @@ def get_or_create_prefix(host, mask_length, default_status, namespace, job=None)
     return prefix
 
 
-def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, default_prefix_status, job=None):
+def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, default_ip_role, default_prefix_status, job=None):
     """Attempt to get a Nautobot IPAddress, and create a new one if necessary."""
     ip_address = None
 
@@ -76,6 +76,7 @@ def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, de
                 address=f"{host}/{mask_length}",
                 namespace=namespace,
                 status=default_ip_status,
+                role=default_ip_role,
             )
             ip_address.validated_save()
         except ValidationError:
@@ -88,6 +89,7 @@ def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, de
             ip_address = IPAddress.objects.create(
                 address=f"{host}/{mask_length}",
                 status=default_ip_status,
+                role=default_ip_role,
                 parent=prefix,
             )
         try:


### PR DESCRIPTION
# Closes: #389

## What's Changed

This PR adds the ability to assign a secondary IP to an interface. You can use this example to parse the output of show ip interface (eg. Cisco xe)

```
commands:
  - command: "show ip interface"
    parser: "textfsm"
    jpath: "[?interface=='{{ current_key }}'].{ip_address: ip_address, prefix_length: prefix_length}"
    post_processor: "{{ obj | parse_cisco_xe_show_ip_interface | tojson }}"

```
The following changes were made:

- In sync_network_data_models.py I have aded the role to 'class SyncNetworkDataIPAddress'. I have modified create and update so that the role is considered.

- In sync_network_data_adapters.py I have modified 'load_ip_addresses' in 'class SyncNetworkDataNautobotAdapter' and in 'class SyncNetworkDataNetworkAdapter'

- In 'diffsync_utils.py' I have modiefied 'get_or_create_ip_address'

- In jinja_filters.py I have added a parser 'parse_cisco_xe_show_ip_interface'

## To Do

As mentioned in the slack channel, I'm not that familiar with the tests. By adding the role, the test now fails. This still needs to be adjusted. Sorry for the inconvenience.

- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
