### PR TITLE
Assign secondary IP-Address to Interface

### DIFF
--- a/changes/389.fixed
+++ b/changes/389.fixed
@@ -1,0 +1,3 @@
+Add role to the IP-Address model.
+Added jinja filter to parse the output of 'show ip interface'.
+Add the ability to assign a secondary IP-address to an interface.

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -120,6 +120,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
                 type=ip_address.type,
                 ip_version=ip_address.ip_version,
                 status__name=ip_address.status.name,
+                role__name=ip_address.role.name if ip_address.role else None,
             )
             try:
                 network_ip_address.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
@@ -614,6 +615,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                                     type="host",
                                     ip_version=4,
                                     status__name=self.job.ip_address_status.name,
+                                    role__name=ip_address.get("role", None),
                                 )
                                 self.add(network_ip_address)
                             except diffsync.exceptions.ObjectAlreadyExists:

--- a/nautobot_device_onboarding/jinja_filters.py
+++ b/nautobot_device_onboarding/jinja_filters.py
@@ -162,6 +162,51 @@ def get_vlan_data(item, vlan_mapping, tag_type):  # pylint: disable=too-many-ret
             ]
     return []
 
+@library.filter
+def parse_cisco_xe_show_ip_interface(item):
+    """Parse Cisco XE show ip interface.
+
+    The first IP address is considered the primary IP address, and subsequent addresses are secondary.
+
+    Example:
+    [
+        {
+            "IP_ADDRESS": [
+                "192.168.178.240",
+                "192.168.178.120"
+            ],
+            "PREFIX_LENGTH": [
+                "24",
+                "24"
+            ],
+        }
+    ]
+
+    you can use this filter in Jinja2 templates like this:
+
+    interfaces__ip_addresses:
+      commands:
+        - command: "show ip interface"
+           parser: "textfsm"
+           jpath: "[?interface=='{{ current_key }}'].{ip_address: ip_address, prefix_length: prefix_length}"
+           post_processor: "{{ obj | parse_cisco_xe_show_ip_interface | tojson }}"
+
+    """
+    if isinstance(item, list) and len(item) > 0:
+        result = []
+        for interface in item:
+            for i in range(len(interface["ip_address"])):
+                if interface["ip_address"][i] and interface["prefix_length"][i]:
+                    ip = {
+                        "prefix_length": interface["prefix_length"][i],
+                        "ip_address": interface["ip_address"][i]
+                    }
+                    if i > 0:
+                        ip["role"] = "Secondary"
+                    result.append(ip)
+        return result
+    return []
+
 
 @library.filter
 def parse_junos_ip_address(item):

--- a/nautobot_device_onboarding/utils/diffsync_utils.py
+++ b/nautobot_device_onboarding/utils/diffsync_utils.py
@@ -5,6 +5,7 @@ import ipaddress
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from nautobot.apps.choices import PrefixTypeChoices
 from nautobot.dcim.models import Device
+from nautobot.extras.models import Role
 from nautobot.ipam.models import IPAddress, Prefix
 
 
@@ -61,10 +62,9 @@ def get_or_create_prefix(host, mask_length, default_status, namespace, job=None)
     return prefix
 
 
-def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, default_prefix_status, job=None):
+def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, default_prefix_status, default_ip_role=None, job=None):
     """Attempt to get a Nautobot IPAddress, and create a new one if necessary."""
     ip_address = None
-
     try:
         ip_address = IPAddress.objects.get(
             host=host,
@@ -77,6 +77,8 @@ def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, de
                 namespace=namespace,
                 status=default_ip_status,
             )
+            if default_ip_role:
+                ip_address.role = Role.objects.get(name=default_ip_role)
             ip_address.validated_save()
         except ValidationError:
             if job:
@@ -90,6 +92,8 @@ def get_or_create_ip_address(host, mask_length, namespace, default_ip_status, de
                 status=default_ip_status,
                 parent=prefix,
             )
+            if default_ip_role:
+                ip_address.role = Role.objects.get(name=default_ip_role)
         try:
             ip_address.validated_save()
         except ValidationError as err:


### PR DESCRIPTION
# Closes: #389

## What's Changed

This PR adds the ability to assign a secondary IP to an interface. You can use this example to parse the output of show ip interface (eg. Cisco xe)

```
commands:
  - command: "show ip interface"
    parser: "textfsm"
    jpath: "[?interface=='{{ current_key }}'].{ip_address: ip_address, prefix_length: prefix_length}"
    post_processor: "{{ obj | parse_cisco_xe_show_ip_interface | tojson }}"

```

## To Do

- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
