### PR TITLE
junos command mapper: Fix post_processor for interfaces__link_status command to return False when link_status is down

### DIFF
--- a/nautobot_device_onboarding/command_mappers/juniper_junos.yml
+++ b/nautobot_device_onboarding/command_mappers/juniper_junos.yml
@@ -82,7 +82,7 @@ sync_network_data:
       - command: "show interfaces | display json"
         parser: "none"
         jpath: '"interface-information"[]["physical-interface"[?name[?data==`{{ current_key.split(".")[0] }}`]]][][]."admin-status"[].data'  # yamllint disable-line rule:quoted-strings
-        post_processor: "{% if obj | length > 0 %}{{ obj[0] | interface_status_to_bool }}{% else %}{{ obj }}{% endif %}"
+        post_processor: "{% if obj | length > 0 %}{{ obj[0] | interface_status_to_bool }}{% else %}False{% endif %}"
   interfaces__802.1Q_mode:
     commands:
       - command: "show interfaces | display json"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
In the Junos command mapper (nautobot_device_onboarding/command_mappers/juniper_junos.yml), the post_processor for the interfaces__link_status command currently returns {{obj}} when {% if obj | length > 0 %} is used. This results in "[]", which causes validation to fail against the SyncNetworkDataInterface model. The fix is to return False instead, so that it correctly maps to the enabled field in the model.