### PR TITLE
    FEAT: ✨ add support for more vendors and improve F5 TMSH support.

### DIFF
--- a/nautobot_device_onboarding/command_mappers/aruba_aoscx.yml
+++ b/nautobot_device_onboarding/command_mappers/aruba_aoscx.yml
@@ -32,3 +32,103 @@ sync_devices:
         jpath: "[?contains(ip_address, `{{ obj }}/`)].ip_address"
         post_processor: "{{ obj[0].split('/')[1] }}"
         iterable_type: "int"
+sync_network_data:
+  pre_processor:
+    vlan_map:
+      commands:
+        - command: "show vlan"
+          parser: "textfsm"
+          jpath: "[*].[$vlan_id$,vlan_name]"
+          post_processor: "{{ obj | flatten_list_of_dict_from_value('vlan_name') | tojson }}"
+  software_version:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].version"
+  serial:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].serial"
+  interfaces:
+    root_key: true
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[*].interface"
+        post_processor: "{% set result={} %}{% for interface in obj %}{{ result.update({interface: {}}) or '' }}{% endfor %}{{ result | tojson }}"
+  interfaces__type:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].hw_type"
+        post_processor: "{% if 'lag' in current_key %}{{ 'lag' }}{% else %}{{ obj[0] | lower | map_interface_type }}{% endif %}"
+  interfaces__ip_addresses:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].{ip_address: ip_address}"
+        post_processor: "{% if obj and obj[0]['ip_address'] and '/' in obj[0]['ip_address'] %}{% set cidr = obj[0]['ip_address'].split('/') %}{% set ip = cidr[0] %}{% set mask = cidr[1] | int %}{{ obj[0].update({'ip_address': ip, 'prefix_length': mask}) or obj | tojson }}{% else %}{{ obj | tojson }}{% endif %}"
+        iterable_type: "list"
+  interfaces__mtu:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].mtu"
+        iterable_type: "str"
+  interfaces__mac_address:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].mac_address"
+  interfaces__description:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].interface_desc"
+  interfaces__link_status:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].link_status"
+        post_processor: "{{ obj[0] | interface_status_to_bool }}"
+  interfaces__802.1Q_mode:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].{mode: vlan_mode, trunking_vlans: vlan_trunk}"
+        post_processor: "{% if obj and 'tagged' in obj[0]['mode'] %}{{ 'tagged' }}{% else %}{{ 'access' }}{% endif %}"
+        iterable_type: "str"
+  interfaces__lag:
+    commands:
+      - command: "show interface | begin lag"
+        parser: "textfsm"
+        jpath: "[?contains(@.aggregated_interfaces, `{{ current_key }}`)].interface"
+        post_processor: "{% if obj | length > 0 %}{{ obj[0] | canonical_interface_name }}{% else %}{{ obj }}{% endif %}"
+        iterable_type: "str"
+  interfaces__vrf:
+    commands:
+      - command: "show vrf"
+        parser: "textfsm"
+        jpath: "[?contains(@.vrf_interfaces, `{{ current_key }}`)].{name:vrf_name}"
+        post_processor: "{% if obj | length > 0 %}{{ obj[0] | key_exist_or_default('name') | tojson }}{% else %}{{ {} | tojson }}{% endif %}"
+        iterable_type: "dict"
+  interfaces__tagged_vlans:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].{mode: vlan_mode, access_vlan: vlan_access, trunking_vlans: vlan_trunk, native_vlan: vlan_native}"
+        post_processor: "{% if obj and 'tagged' in obj[0]['mode'] and obj[0]['trunking_vlans'] %}{% set result = [] %}{% for vlan in obj[0]['trunking_vlans'] %}{% if vlan in vlan_map and vlan != obj[0]['native_vlan'] %}{% set _=result.append({'id': vlan, 'name': vlan_map[vlan]}) %}{% endif %}{% endfor %}{{ result | tojson }}{% else %}{{ [] | tojson }}{% endif %}"
+  interfaces__untagged_vlan:
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].{mode: vlan_mode, access_vlan: vlan_access, trunking_vlans: vlan_trunk, native_vlan: vlan_native}"
+        iterable_type: "dict"
+        post_processor: "{% if obj and 'tagged' in obj[0]['mode'] and obj[0]['native_vlan'] in vlan_map %}{{ {'id': obj[0]['native_vlan'], 'name': vlan_map[obj[0]['native_vlan']]} | tojson }}{% elif obj and 'access' in obj[0]['mode'] and obj[0]['access_vlan'] in vlan_map %}{{ {'id': obj[0]['access_vlan'], 'name': vlan_map[obj[0]['access_vlan']]} | tojson }}{% else %}{{ [] | tojson }}{% endif %}"
+  cables:
+    commands:
+      - command: "show lldp neighbor-info detail"
+        parser: "textfsm"
+        jpath: "[*].{local_interface:local_interface, remote_interface:neighbor_port_id, remote_device:neighbor_name}"
+        post_processor: "{% set result = [] %}{% for cable in obj %}{% set _=result.append({'local_interface': cable['local_interface'], 'remote_interface': cable['remote_interface'], 'remote_device': cable['remote_device'] | remove_fqdn }) %}{% endfor %}{{ result | tojson }}"

--- a/nautobot_device_onboarding/command_mappers/aruba_os.yml
+++ b/nautobot_device_onboarding/command_mappers/aruba_os.yml
@@ -1,0 +1,158 @@
+---
+sync_devices:
+  hostname:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].name"
+  serial:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].serial"
+  device_type:
+    commands:
+      - command: "show lldp info local-device"
+        parser: "textfsm"
+        jpath: "[*].model"
+  mgmt_interface:
+    commands:
+      - command: "show ip"
+        parser: "textfsm"
+        jpath: "[?contains(ip_address, `{{ obj }}`)].intf_name"
+  mask_length:
+    commands:
+      - command: "show ip"
+        parser: "textfsm"
+        jpath: "[?contains(ip_address, `{{ obj }}`)].ip_mask"
+        post_processor: "{{ obj[0] | netmask_to_cidr }}"
+        iterable_type: "int"
+sync_network_data:
+  pre_processor:
+    vlan_map:
+      commands:
+        - command: "show vlans"
+          parser: "textfsm"
+          jpath: "[*].[$vlan_id$,vlan_name]"
+          post_processor: "{{ obj | flatten_list_of_dict_from_value('vlan_name') | tojson }}"
+    trunk_map:
+      commands:
+        - command: "show trunks"
+          parser: "textfsm"
+          jpath: "[*].trunk"
+          # Due to the nature of Procurve ports (standalone|stack) we cannot use jmspath filter here.
+          post_processor: "{% set result = obj | unique | list %}{% if result | length == 1 %}{{ [obj] | list | tojson }}{% else %}{{ result | tojson }}{% endif %}"
+          iterable_type: "list"
+    ip_map:
+      commands:
+        - command: "show ip"
+          parser: "textfsm"
+          jpath: "[*].[$intf_name$,ip_address,ip_mask]"
+          post_processor: "{{ obj | flatten_list_of_dict_from_value('ip_address') | tojson }}"
+  software_version:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].software_version"
+  serial:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].serial"
+  interfaces:
+    root_key: true
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[*].port"
+        post_processor: "{% set result={} %}{% for interface in obj %}{% set intf_name = interface.split('-Trk')[0] %}{{ result.update({intf_name: {}}) or '' }}{% endfor %}{% for vlan_name in ip_map.keys() %}{{ result.update({vlan_name: {}}) or '' }}{% endfor %}{% for trunk in trunk_map %}{{ result.update({trunk: {}}) or '' }}{% endfor %}{{ result | tojson }}"
+  interfaces__type:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].type"
+        post_processor: "{% if 'Trk' in current_key %}{{ 'lag' }}{% elif obj | length > 0 %}{{ {'100/1000T': '1000base-t','1000SX':'1000base-x-sfp'}.get(obj[0], 'other') }}{% else %}{{ 'other' }}{% endif %}"
+  interfaces__ip_addresses:
+    commands:
+      - command: "show ip"
+        parser: "textfsm"
+        jpath: "[?contains(@.intf_name, `{{ current_key }}`)].{ip_address: ip_address, prefix_length: ip_mask}"
+        post_processor: "{% if obj and obj[0]['ip_address'] and obj[0]['prefix_length'] %}{% set mask = obj[0]['prefix_length'] | netmask_to_cidr %}{{ [{'ip_address': obj[0]['ip_address'], 'prefix_length': mask}] | tojson }}{% else %}{{ obj | tojson }}{% endif %}"
+        iterable_type: "list"
+  interfaces__mtu:
+    # MANDATORY, but ArubaOS does not provide a method to access this intf data.
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].mtu"
+        post_processor: "{{ '1500' }}"
+        iterable_type: "str"
+  interfaces__mac_address:
+    # MANDATORY, but ArubaOS only provides system mac data.
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].mac_address"
+        post_processor: "{% if obj | length > 0 %}{{ obj[0] }}{% else %}{{ '' }}{% endif %}"
+  interfaces__description:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].name"
+        iterable_type: "str"
+  interfaces__link_status:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].status"
+        post_processor: "{% if obj %}{{ obj[0] | interface_status_to_bool }}{% else %}{{ 'False' }}{% endif %}"
+        iterable_type: "bool"
+  interfaces__802.1Q_mode:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].{access_vlan: untagged, trunking_vlans: tagged}"
+        post_processor: "{% if (obj and 'multi' in obj[0]['trunking_vlans']) or ('Trk' in current_key) %}{{ 'tagged' }}{% else %}{{ 'access' }}{% endif %}"
+        iterable_type: "str"
+  interfaces__lag:
+    commands:
+      - command: "show trunks"
+        parser: "textfsm"
+        jpath: "[*].{port: local_port, lag: trunk}"
+        post_processor: "{% if obj | length > 0 %}{% for intf in obj %}{% if intf['port'] | string == current_key %}{{ intf['lag'] }}{% else %}{{ '' }}{% endif %}{% endfor %}{% endif %}"
+        iterable_type: "str"
+  interfaces__vrf: # not supported by platform, implemented to avoid user errors when onboarding multiple platforms at once.
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].name"
+        post_processor: "{{ {} | tojson }}"
+        iterable_type: "dict"
+  interfaces__tagged_vlans:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].{access_vlan: untagged, trunking_vlans: tagged}"
+        post_processor: "{% if obj and 'multi' in obj[0]['trunking_vlans'] or ('Trk' in current_key) %}{% set result = [] %}{% for vid,name in vlan_map.items() %}{% if 'Trk' in current_key %}{% set _=result.append({'id': vid, 'name': name}) %}{% elif vid != obj[0]['access_vlan'] %}{% set _=result.append({'id': vid, 'name': name}) %}{% endif %}{% endfor %}{{ result | tojson }}{% endif %}"
+  interfaces__untagged_vlan:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].{access_vlan: untagged, trunking_vlans: tagged}"
+        iterable_type: "dict"
+        post_processor: "{% if obj and obj[0]['access_vlan'] in vlan_map %}{{ {'id': obj[0]['access_vlan'], 'name': vlan_map[obj[0]['access_vlan']]} | tojson }}{% else %}{{ [] | tojson }}{% endif %}"
+  cables:
+    commands:
+      - command: "show lldp info remote-device detail"
+        parser: "textfsm"
+        jpath: "[*].{local_interface:local_interface, remote_interface:neighbor_interface, remote_device:neighbor_name, description: neighbor_description, intf_description: neighbor_interface_description}"
+        post_processor: |
+          {% set result = [] %}
+          {% for cable in obj %}
+            {% if cable['description'].startswith('HP') or cable['description'].startswith('HPE') %}
+              {% set _=result.append({'local_interface': cable['local_interface'], 'remote_interface': cable['intf_description'], 'remote_device': cable['remote_device'] | remove_fqdn }) %}
+            {% else %}
+              {% set _=result.append({'local_interface': cable['local_interface'], 'remote_interface': cable['remote_interface'], 'remote_device': cable['remote_device'] | remove_fqdn }) %}
+            {% endif %}
+          {% endfor %}
+          {{ result | tojson }}

--- a/nautobot_device_onboarding/command_mappers/brocade_fastiron.yml
+++ b/nautobot_device_onboarding/command_mappers/brocade_fastiron.yml
@@ -1,0 +1,231 @@
+---
+sync_devices:
+  hostname:
+    commands:
+      - command: "show configuration | i hostname"
+        parser: "raw"
+        jpath: "raw"
+        post_processor: "{{ obj.split('hostname ')[1].strip() if 'hostname ' in obj else 'Unknown-Hostname' }}"
+  serial:
+    commands:
+      - command: "show version"
+        parser: "textfsm"
+        jpath: "[0].serial"
+        post_processor: "{% if obj and obj[0] %}{{ obj[0] }}{% else %}{{ 'unknown-serial' }}{% endif %}"
+  device_type:
+    commands:
+      - command: "show version"
+        parser: "textfsm"
+        jpath: "[0].model"
+        post_processor: "{% if obj and obj[0] %}{{ obj[0] }}{% else %}{{ 'unknown-model' }}{% endif %}"
+  mgmt_interface:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[*].interface"
+        post_processor: "{% if obj and (obj | length > 0) and 've300' in obj %}{{ 've300' }}{% else %}{{ 'mgmt1' }}{% endif %}"
+  mask_length:
+    commands:
+      - command: "show run | i ip address"
+        parser: "raw"
+        jpath: "raw"
+        post_processor: "{{ obj.strip().split('\\n')[-1].split()[3] | netmask_to_cidr }}"
+        iterable_type: "int"
+
+sync_network_data:
+  pre_processor:
+    vlan_map:
+      commands:
+        - command: "show vlan"
+          parser: "textfsm"
+          jpath: "[*].[$vlan_id$,vlan_name]"
+          post_processor: "{{ obj | flatten_list_of_dict_from_value('vlan_name') | tojson }}"
+    vlan_port_map:
+      commands:
+        - command: "show vlan"
+          parser: "textfsm"
+          jpath: "[*].{stack: stack_id, slot: slot, port: port, vid: vlan_id, name: vlan_name, mode: status, lag: lag}"
+          post_processor: |
+            {% set ns = namespace(result={}) %}
+            {% for port in obj %}
+              {% if 'LAG' in port.lag %}
+                {% set intf = ('lg' ~ port.port) %}
+              {% else %}
+                {% set intf = (port.stack ~ '/' ~ port.slot ~ '/' ~ port.port) %}
+              {% endif %}
+              {% if intf not in ns.result.keys() %}
+                {% set _= ns.result.update({intf: []}) %}
+              {% endif %}
+              {% if port.vid and port.mode != 'Untagged' %}
+                {% set _= ns.result[intf].append({'id': port.vid, 'name': port.name}) %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.result | tojson }}
+          iterable_type: "dict"
+    ip_map:
+      commands:
+        - command: "show running-config interface"
+          parser: "textfsm"
+          jpath: "[*].{intf: interface, intf_type: interface_type, ip_addr: ip_address, mask: ip_addr_cidr}"
+          post_processor: |
+            {% set result = {} %}
+            {% for item in obj %}
+              {% set intf_name = (item.intf_type ~ item.intf) %}
+              {% if item.ip_addr and item.mask %}
+                {% set cidr = {'ip_address': item.ip_addr, 'prefix_length': (item.mask | netmask_to_cidr)} %}
+                {% set _ = result.update({intf_name: cidr}) %}
+              {% endif %}
+            {% endfor %}
+            {{ result | tojson }}
+          iterable_type: "dict"
+    ruckus_mgmt_map:
+      commands:
+        - command: "show run | i ip address"
+          parser: "raw"
+          jpath: "raw"
+          post_processor: |
+            {% set mask = (obj.strip().split('\\n')[-1].split()[3] | netmask_to_cidr) %}
+            {% set ip_addr = obj.strip().split('\\n')[-1].split()[2] %}
+            {{ {'ip_address': ip_addr, 'prefix_length': mask} | tojson }}
+          iterable_type: "dict"
+  software_version:
+    commands:
+      - command: "show version"
+        parser: "textfsm"
+        jpath: "[*].sw_version[0]"
+  serial:
+    commands:
+      - command: "show version"
+        parser: "textfsm"
+        jpath: "[0].serial"
+        post_processor: "{% if obj and obj[0] %}{{ obj[0] }}{% else %}{{ 'unknown-serial' }}{% endif %}"
+  interfaces:
+    root_key: true
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[*].interface"
+        post_processor: "{% set result={} %}{% for interface in obj %}{% set intf_name = interface.split('-Trk')[0] %}{{ result.update({intf_name: {}}) or '' }}{% endfor %}{{ result | tojson }}"
+  interfaces__type:
+    commands:
+      - command: "show media"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].{speed: speed, media: media, hw_type_gen: hw_type_generic}"
+        post_processor: |
+          {% if 'lg' in current_key %}
+          {{-'lag'-}}
+          {% elif obj and obj[0] and obj[0]['speed'] != 'EMPTY' %}
+          {{-{'M-C': '1000base-t','M-LX':'1000base-x-sfp','M-SX':'1000base-x-sfp','SR':'10gbase-x-sfpp','LR':'10gbase-x-sfpp','Active':'10gbase-t'}.get(obj[0]['media'], 'other')-}}
+          {% else %}
+          {{-'other'-}}
+          {% endif %}
+        iterable_type: "str"
+  interfaces__ip_addresses:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].{name: interface}"
+        post_processor: |
+          {% set ns = namespace(has_ve=false) %}
+          {% for k in ip_map.keys() %}
+            {% if 've' in k %}
+              {% set ns.has_ve = true %}
+            {% endif %}
+          {% endfor %}
+          {% if 've' in current_key and ns.has_ve and (current_key in ip_map) %}
+          {{- [ip_map[current_key]] | tojson -}}
+          {% elif current_key == 'mgmt1' and not ns.has_ve %}
+          {{- [ruckus_mgmt_map] | tojson -}}
+          {% else %}
+          {{- [] | tojson -}}
+          {% endif %}
+        iterable_type: "list"
+  interfaces__mtu:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].mtu"
+        post_processor: "{% if obj and obj[0] %}{{ obj[0] }}{% else %}{{ '1500' }}{% endif %}"
+        iterable_type: "str"
+  interfaces__mac_address:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].mac"
+        post_processor: "{% if obj | length > 0 %}{{ obj[0] }}{% else %}{{ '' }}{% endif %}"
+  interfaces__description:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].name"
+        iterable_type: "str"
+  interfaces__link_status:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].linkstate"
+        post_processor: "{% if obj %}{{ obj[0] | interface_status_to_bool }}{% else %}{{ 'False' }}{% endif %}"
+        iterable_type: "bool"
+  interfaces__802.1Q_mode:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].tagonly"
+        post_processor: "{% if obj and 'Yes' in obj[0] %}{{ 'tagged' }}{% else %}{{ 'access' }}{% endif %}"
+        iterable_type: "str"
+  interfaces__lag:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].trunkid"
+        post_processor: "{% if obj and (obj[0] in ['None', 'N/A']) or 'lg' in current_key %}{{ '' }}{% else %}{{ 'lg' ~ obj[0] }}{% endif %}"
+        iterable_type: "str"
+  interfaces__vrf: # not supported by platform, implemented to avoid user errors when onboarding multiple platforms at once.
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].name"
+        post_processor: "{{ {} | tojson }}"
+        iterable_type: "dict"
+  interfaces__tagged_vlans:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].{trunk: tagonly, untagged: pvid}"
+        post_processor: |
+          {% set ns = namespace(result=[]) %}
+          {% if obj and obj[0] and 'Yes' in obj[0]['trunk'] %}
+            {% if current_key in vlan_port_map %}
+              {% for vlan in vlan_port_map[current_key] %}
+                {% if vlan.id != obj[0]['untagged'] %}
+                  {% set _= ns.result.append(vlan) %}
+                {% endif %}
+              {% endfor %}
+            {% else %}
+              {% set ns.result = [] %}
+            {% endif %}
+          {% else %}
+            {% set ns.result = [] %}
+          {% endif %}
+          {{ ns.result | tojson }}
+        iterable_type: "list"
+  interfaces__untagged_vlan:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].pvid"
+        post_processor: "{% if obj and obj[0] and obj[0] in ['None', 'N/A'] or obj[0] not in vlan_map %}{{ [] | tojson }}{% else %}{{ {'id': obj[0],'name': vlan_map[obj[0]]} | tojson }}{% endif %}"
+        iterable_type: "dict"
+  cables:
+      commands:
+        - command: "show lldp neighbors detail"
+          parser: "textfsm"
+          jpath: "[*].{local_interface:local_interface, remote_interface:neighbor_interface, remote_device:neighbor_name}"
+          post_processor: |
+            {% set result = [] %}
+            {% for cable in obj %}
+              {% if cable['local_interface'] and cable['remote_interface'] and (cable['remote_device'] | remove_fqdn) %}
+                {% set _=result.append({'local_interface': cable['local_interface'], 'remote_interface': cable['remote_interface'], 'remote_device': (cable['remote_device'] | remove_fqdn) }) %}
+              {% endif %}
+            {% endfor %}
+            {{ result | tojson }}

--- a/nautobot_device_onboarding/command_mappers/f5_tmsh.yml
+++ b/nautobot_device_onboarding/command_mappers/f5_tmsh.yml
@@ -4,15 +4,15 @@ sync_devices:
     commands:
       - command: "show cm device"
         parser: "ttp"
-        jpath: "[]|[?mgmt_ip==`{{ obj }}`].mgmt_hostname"
-        post_processor: "{{ obj[0] }}"
+        jpath: "[*].systems[?(@.mgmt_ip==`{{ obj }}`)].hostname[]"
+        post_processor: "{{ obj[0] | remove_fqdn }}"
         iterable_type: "str"
   serial:
     commands:
       - command: "show sys hardware"
         parser: "ttp"
-        jpath: "[*].serial_number"
-        post_processor: "{{ obj[0] }}"
+        jpath: "[*].{model: model_type, sn: serial_number, mac: base_mac}"
+        post_processor: "{% if ('vCMP' in obj[0].model) or ('Virtual' in obj[0].model) %}{{ obj[0].mac }}{% else %}{{ obj[0].sn }}{% endif %}"
         iterable_type: "str"
   device_type:
     commands:
@@ -23,14 +23,224 @@ sync_devices:
         iterable_type: "str"
   mgmt_interface:
     commands:
-      - command: "show net interface | grep mgmt | grep up"
-        parser: "raw"
-        jpath: "raw"
-        post_processor: "{{ obj.split(' ')[0] }}"
+      - command: "show sys hardware"
+        parser: "ttp"
+        jpath: "[*].model_type"
+        post_processor: "{{ 'mgmt' }}"
+        iterable_type: "str"
   mask_length:
     commands:
-      - command: "show sys cluster"
+      - command: "list sys management-ip"
         parser: "ttp"
-        jpath: "[*].mgmt_mask"
+        jpath: "[*].mgmt_netmask"
         post_processor: "{{ obj[0] }}"
         iterable_type: "int"
+
+sync_network_data:
+  pre_processor:
+      vlan_map:
+        commands:
+        - command: "list net vlan"
+          parser: "ttp"
+          jpath: "[0]"
+          post_processor: "{% set result={} %}{% if obj | length > 0 %}{% for name, attrs in obj.items() %}{{ result.update({attrs.vlan_id: {'vlan_name': name}}) or '' }}{% endfor %}{% endif %}{{ result | tojson }}"
+          iterable_type: "dict"
+      vlan_int_map:
+        commands:
+        - command: "list net vlan"
+          parser: "ttp"
+          jpath: "[0]"
+          post_processor: |
+            {% set result = {} %}
+            {% for name, attrs in obj.items() %}
+              {% if attrs.members is defined %}
+                {% for member in attrs.members %}
+                  {% if member.interface != 'none' %}
+                    {% if member.interface not in result %}
+                      {% set _ = result.update({member.interface: {'tagged': [], 'untagged': []}}) %}
+                    {% endif %}
+                    {% if member.dot1q is defined %}
+                      {% set _ = result[member.interface][member.dot1q].append({'id': attrs.vlan_id, 'name': name}) %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ result | tojson }}
+          iterable_type: "dict"
+      trunk_map:
+        commands:
+        - command: "list net trunk"
+          parser: "ttp"
+          jpath: "[0]"
+          iterable_type: "list"
+      ip_map:
+        commands:
+        - command: "list net self"
+          parser: "ttp"
+          jpath: "[0]"
+          post_processor: "{{ obj | tojson }}"
+          iterable_type: "list"
+
+  serial:
+    commands:
+      - command: "show sys hardware"
+        parser: "ttp"
+        jpath: "[*].{model: model_type, sn: serial_number, mac: base_mac}"
+        post_processor: "{% if ('vCMP' in obj[0].model) or ('Virtual' in obj[0].model) %}{{ obj[0].mac }}{% else %}{{ obj[0].sn }}{% endif %}"
+        iterable_type: "str"
+  interfaces:
+    root_key: true
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: "[].keys(@)[]"
+        post_processor: |
+          {% set result={} %}
+          {% for interface in obj %}
+            {% set _=result.update({interface: {}}) or '' %}
+          {% endfor %}
+          {% if trunk_map is mapping %}
+            {% for trunk in trunk_map.keys() %}
+              {% set _=result.update({trunk: {}}) or '' %}
+            {% endfor %}
+          {% endif %}
+          {% if vlan_map is mapping %}
+            {% for vlan in vlan_map.values() %}
+              {% set _=result.update({vlan.vlan_name: {}}) or '' %}
+            {% endfor %}
+          {% endif %}
+          {{ result | tojson }}
+  interfaces__type:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".{media:media}'
+        post_processor: |
+          {% if current_key in trunk_map %}
+          {{-'lag'-}}
+          {% elif obj and obj[0] and obj[0].media != 'none' %}
+          {{-{'1000T-FD': '1000base-t', '10000SR-FD':'10gbase-x-sfpp','10000LR-FD':'10gbase-x-sfpp','40000SRBD-FD':'40gbase-x-qsfpp'}.get(obj[0]['media'], 'other')-}}
+          {% else %}
+          {{-'other'-}}
+          {% endif %}
+        iterable_type: "str"
+  interfaces__ip_addresses:
+    commands:
+      - command: "list sys management-ip"
+        parser: "ttp"
+        jpath: "[*].{ip_address:mgmt_ip, prefix_length:mgmt_netmask}"
+        post_processor: |
+          {% if current_key == 'mgmt' %}
+          {{- obj | tojson -}}
+          {% elif current_key in ip_map %}
+          {{- ip_map[current_key] | tojson -}}
+          {% else %}
+          {{- [] | tojson -}}
+          {% endif %}
+        iterable_type: "list"
+  interfaces__mtu:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".mtu'
+        post_processor: |
+          {% if current_key in trunk_map %}
+          {{-'9198'-}}         
+          {% elif obj and obj[0] and obj[0] != 'none' %}
+          {{-obj[0]-}}
+          {% else %}
+          {{-'1500'-}}
+          {% endif %}
+        iterable_type: "str"
+  interfaces__mac_address:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".mac'
+        post_processor: |
+          {% if current_key in trunk_map %}
+          {{-trunk_map[current_key].mac_address-}}
+          {% elif obj and obj[0] and obj[0] != 'none' %}
+          {{-obj[0]-}}
+          {% else %}
+          {{-''-}}
+          {% endif %}
+        iterable_type: "str"
+  interfaces__description:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".mac'
+        post_processor: "{{ 'no description' }}"
+  interfaces__link_status:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".status'
+        post_processor: "{% if (current_key in trunk_map and trunk_map[current_key].if_list != 'none') or 'VLAN_' in current_key %}{{ 'True' }}{% elif obj %}{{ obj[0] | interface_status_to_bool }}{% else %}{{ 'False' }}{% endif %}"
+  interfaces__802.1Q_mode:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".trunk'
+        post_processor: "{% if (current_key in trunk_map) or (obj | length > 0 and obj[0] != 'none') or (vlan_int_map[current_key] is defined and vlan_int_map[current_key]['tagged'] | length > 0) %}{{ 'tagged' }}{% else %}{{ 'access' }}{% endif %}"
+        iterable_type: "str"
+  interfaces__lag:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".trunk'
+        post_processor: |         
+          {% if obj and obj[0] and obj[0] != 'none' %}
+          {{-obj[0]-}}
+          {% else %}
+          {{-''-}}
+          {% endif %}
+        iterable_type: "str"
+  interfaces__vrf: # F5 uses route domains. Not in use at this moment.
+      commands:
+        - command: "show net interface all-properties"
+          parser: "ttp"
+          jpath: '[]."{{ current_key }}".trunk'
+          post_processor: "{{ {} | tojson }}"
+          iterable_type: "dict"
+  interfaces__tagged_vlans:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".trunk'
+        post_processor: |
+          {% if current_key in vlan_int_map %}
+          {{-vlan_int_map[current_key]['tagged'] | tojson-}}
+          {% else %}
+          {{-{} | tojson-}}
+          {% endif %}
+  interfaces__untagged_vlan:
+    commands:
+      - command: "show net interface all-properties"
+        parser: "ttp"
+        jpath: '[]."{{ current_key }}".trunk'
+        post_processor: |
+          {% if current_key in vlan_int_map %}
+          {{-vlan_int_map[current_key]['untagged'] | tojson-}}
+          {% else %}
+          {{-[] | tojson-}}
+          {% endif %}
+        iterable_type: "dict"
+  software_version:
+    commands:
+      - command: "show sys version"
+        parser: "ttp"
+        jpath: "[0].version"
+  cables:
+    commands:
+      - command: "show net lldp-neighbors all-properties"
+        parser: "ttp"
+        jpath: "[0].lldp_neighbors[].{lport: local_port, rport: port_id, sysname: system_name}"
+        post_processor: |
+          {% set result = [] %}
+          {% for cable in obj %}
+              {% set _=result.append({'local_interface': cable['lport'], 'remote_interface': cable['rport'], 'remote_device': cable['sysname'] | remove_fqdn }) %}
+          {% endfor %}
+          {{ result | tojson }}

--- a/nautobot_device_onboarding/command_mappers/hp_procurve.yml
+++ b/nautobot_device_onboarding/command_mappers/hp_procurve.yml
@@ -1,0 +1,158 @@
+---
+sync_devices:
+  hostname:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].name"
+  serial:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].serial"
+  device_type:
+    commands:
+      - command: "show lldp info local-device"
+        parser: "textfsm"
+        jpath: "[*].model"
+  mgmt_interface:
+    commands:
+      - command: "show ip"
+        parser: "textfsm"
+        jpath: "[?contains(ip_address, `{{ obj }}`)].intf_name"
+  mask_length:
+    commands:
+      - command: "show ip"
+        parser: "textfsm"
+        jpath: "[?contains(ip_address, `{{ obj }}`)].ip_mask"
+        post_processor: "{{ obj[0] | netmask_to_cidr }}"
+        iterable_type: "int"
+sync_network_data:
+  pre_processor:
+    vlan_map:
+      commands:
+        - command: "show vlans"
+          parser: "textfsm"
+          jpath: "[*].[$vlan_id$,vlan_name]"
+          post_processor: "{{ obj | flatten_list_of_dict_from_value('vlan_name') | tojson }}"
+    trunk_map:
+      commands:
+        - command: "show trunks"
+          parser: "textfsm"
+          jpath: "[*].trunk"
+          # Due to the nature of Procurve ports (standalone|stack) we cannot use jmspath filter here.
+          post_processor: "{% set result = obj | unique | list %}{% if result | length == 1 %}{{ [obj] | list | tojson }}{% else %}{{ result | tojson }}{% endif %}"
+          iterable_type: "list"
+    ip_map:
+      commands:
+        - command: "show ip"
+          parser: "textfsm"
+          jpath: "[*].[$intf_name$,ip_address,ip_mask]"
+          post_processor: "{{ obj | flatten_list_of_dict_from_value('ip_address') | tojson }}"
+  software_version:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].software_version"
+  serial:
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].serial"
+  interfaces:
+    root_key: true
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[*].port"
+        post_processor: "{% set result={} %}{% for interface in obj %}{% set intf_name = interface.split('-Trk')[0] %}{{ result.update({intf_name: {}}) or '' }}{% endfor %}{% for vlan_name in ip_map.keys() %}{{ result.update({vlan_name: {}}) or '' }}{% endfor %}{% for trunk in trunk_map %}{{ result.update({trunk: {}}) or '' }}{% endfor %}{{ result | tojson }}"
+  interfaces__type:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].type"
+        post_processor: "{% if 'Trk' in current_key %}{{ 'lag' }}{% elif obj | length > 0 %}{{ {'100/1000T': '1000base-t','1000SX':'1000base-x-sfp'}.get(obj[0], 'other') }}{% else %}{{ 'other' }}{% endif %}"
+  interfaces__ip_addresses:
+    commands:
+      - command: "show ip"
+        parser: "textfsm"
+        jpath: "[?contains(@.intf_name, `{{ current_key }}`)].{ip_address: ip_address, prefix_length: ip_mask}"
+        post_processor: "{% if obj and obj[0]['ip_address'] and obj[0]['prefix_length'] %}{% set mask = obj[0]['prefix_length'] | netmask_to_cidr %}{{ [{'ip_address': obj[0]['ip_address'], 'prefix_length': mask}] | tojson }}{% else %}{{ obj | tojson }}{% endif %}"
+        iterable_type: "list"
+  interfaces__mtu:
+    # MANDATORY, but Procurve does not provide a method to access this intf data.
+    commands:
+      - command: "show interface"
+        parser: "textfsm"
+        jpath: "[?interface=='{{ current_key }}'].mtu"
+        post_processor: "{{ '1500' }}"
+        iterable_type: "str"
+  interfaces__mac_address:
+    # MANDATORY, but Procurve only provides system mac data.
+    commands:
+      - command: "show system"
+        parser: "textfsm"
+        jpath: "[*].mac_address"
+        post_processor: "{% if obj | length > 0 %}{{ obj[0] }}{% else %}{{ '' }}{% endif %}"
+  interfaces__description:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].name"
+        iterable_type: "str"
+  interfaces__link_status:
+    commands:
+      - command: "show interfaces brief"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].status"
+        post_processor: "{% if obj %}{{ obj[0] | interface_status_to_bool }}{% else %}{{ 'False' }}{% endif %}"
+        iterable_type: "bool"
+  interfaces__802.1Q_mode:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].{access_vlan: untagged, trunking_vlans: tagged}"
+        post_processor: "{% if (obj and 'multi' in obj[0]['trunking_vlans']) or ('Trk' in current_key) %}{{ 'tagged' }}{% else %}{{ 'access' }}{% endif %}"
+        iterable_type: "str"
+  interfaces__lag:
+    commands:
+      - command: "show trunks"
+        parser: "textfsm"
+        jpath: "[*].{port: local_port, lag: trunk}"
+        post_processor: "{% if obj | length > 0 %}{% for intf in obj %}{% if intf['port'] | string == current_key %}{{ intf['lag'] }}{% else %}{{ '' }}{% endif %}{% endfor %}{% endif %}"
+        iterable_type: "str"
+  interfaces__vrf: # not supported by platform, implemented to avoid user errors when onboarding multiple platforms at once.
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].name"
+        post_processor: "{{ {} | tojson }}"
+        iterable_type: "dict"
+  interfaces__tagged_vlans:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].{access_vlan: untagged, trunking_vlans: tagged}"
+        post_processor: "{% if obj and 'multi' in obj[0]['trunking_vlans'] or ('Trk' in current_key) %}{% set result = [] %}{% for vid,name in vlan_map.items() %}{% if 'Trk' in current_key %}{% set _=result.append({'id': vid, 'name': name}) %}{% elif vid != obj[0]['access_vlan'] %}{% set _=result.append({'id': vid, 'name': name}) %}{% endif %}{% endfor %}{{ result | tojson }}{% endif %}"
+  interfaces__untagged_vlan:
+    commands:
+      - command: "show interfaces status"
+        parser: "textfsm"
+        jpath: "[?port=='{{ current_key }}'].{access_vlan: untagged, trunking_vlans: tagged}"
+        iterable_type: "dict"
+        post_processor: "{% if obj and obj[0]['access_vlan'] in vlan_map %}{{ {'id': obj[0]['access_vlan'], 'name': vlan_map[obj[0]['access_vlan']]} | tojson }}{% else %}{{ [] | tojson }}{% endif %}"
+  cables:
+    commands:
+      - command: "show lldp info remote-device detail"
+        parser: "textfsm"
+        jpath: "[*].{local_interface:local_interface, remote_interface:neighbor_interface, remote_device:neighbor_name, description: neighbor_description, intf_description: neighbor_interface_description}"
+        post_processor: |
+          {% set result = [] %}
+          {% for cable in obj %}
+            {% if cable['description'].startswith('HP') or cable['description'].startswith('HPE') %}
+              {% set _=result.append({'local_interface': cable['local_interface'], 'remote_interface': cable['intf_description'], 'remote_device': cable['remote_device'] | remove_fqdn }) %}
+            {% else %}
+              {% set _=result.append({'local_interface': cable['local_interface'], 'remote_interface': cable['remote_interface'], 'remote_device': cable['remote_device'] | remove_fqdn }) %}
+            {% endif %}
+          {% endfor %}
+          {{ result | tojson }}

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_self.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_self.ttp
@@ -1,0 +1,6 @@
+<group name="{{ interface_id }}*">
+net self {{ ignore }} {
+    address {{ ip_address }}/{{ prefix_length }}
+    vlan {{ interface_id }}
+}
+</group>

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_trunk.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_trunk.ttp
@@ -1,0 +1,9 @@
+<group name="{{ trunk_name }}">
+net trunk {{ trunk_name }} {
+    interfaces {
+        {{ if_list | default('none') | joinmatches(',') | to_list }}
+    }
+    mac-address {{ mac_address | default('00:00:00:00:00:00')| MAC }}
+    lacp-mode {{ lacp_mode | default('none') }}
+}
+</group>

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_vlan.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_vlan.ttp
@@ -1,0 +1,12 @@
+<group name="{{ vlan_name }}">
+net vlan {{ vlan_name }} {
+    <group name="members*">
+    interfaces {
+        {{ interface | default('none') | exclude("poll-interval") | exclude("sampling-rate") }} {{ _line_ }}
+            {{ dot1q | match("tagged|untagged") | default("tagged") }}
+        }
+    }
+    </group>
+    tag {{ vlan_id | default('none') }}
+}
+</group>

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_sys_management-ip.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_sys_management-ip.ttp
@@ -1,0 +1,1 @@
+sys management-ip {{ mgmt_ip }}/{{ mgmt_netmask }}{{ ignore(".*") }}

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_cm_device.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_cm_device.ttp
@@ -1,2 +1,5 @@
-Hostname {{ mgmt_hostname }}
+<group name="systems*">
+Hostname {{ hostname }}
 Mgmt IP {{ mgmt_ip }}
+Device HA State {{ ha_state }}
+</group>

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_net_interface_all-properties.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_net_interface_all-properties.ttp
@@ -1,0 +1,3 @@
+<group name="{{ name }}" method="table">
+{{ name }} {{ status }} {{ mac | MAC }} {{ mtu }} {{ ignore(".*") }} {{ media }} {{ flow }} {{ trunk }} {{ aggr }}
+</group>

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_net_lldp-neighbors_all-properties.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_net_lldp-neighbors_all-properties.ttp
@@ -1,0 +1,11 @@
+{{ ignore | re(".*-----.*") }}
+{{ ignore | re(".*LLDP Neighbours.*") }}
+{{ ignore | re(".*Chassis-ID.*") }}
+{{ ignore | re(".*-----.*") }}
+<group name="lldp_neighbors">
+{{ local_port | re("\d+\.\d+") }} {{ chassis_id }} {{ port_id }}
+Port Description:  {{ port_description | ORPHRASE }}
+System Name:  {{ system_name | ORPHRASE }}
+System Description:  {{ system_description | ORPHRASE }}
+Management Address:  {{ management_address | IP }}
+</group>

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_cluster.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_cluster.ttp
@@ -1,1 +1,0 @@
-Address {{ mgmt_ip }}/{{ mgmt_mask }}

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_hardware.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_hardware.ttp
@@ -1,8 +1,9 @@
 <group name="_">
 Platform {{ _start_ }}
   Name  {{ model_type | ORPHRASE }}
+  Base MAC {{ base_mac | MAC }}
 {{ _end_ }}
 System Information {{ _start_ }}
-  Chassis Serial  {{ serial_number | ORPHRASE }}
+  Appliance Serial  {{ serial_number | ORPHRASE }}
 {{ _end_ }}
 </group>

--- a/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_version.ttp
+++ b/nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_version.ttp
@@ -1,0 +1,5 @@
+Sys::Version
+Main Package
+  Product {{ os }}
+  Version {{ version }}
+  Build {{ hotfix }}


### PR DESCRIPTION
	modified:   nautobot_device_onboarding/command_mappers/aruba_aoscx.yml
	new file:   nautobot_device_onboarding/command_mappers/aruba_os.yml
	new file:   nautobot_device_onboarding/command_mappers/brocade_fastiron.yml
	modified:   nautobot_device_onboarding/command_mappers/f5_tmsh.yml
	new file:   nautobot_device_onboarding/command_mappers/hp_procurve.yml
	new file:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_self.ttp
	new file:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_trunk.ttp
	new file:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_net_vlan.ttp
	new file:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_list_sys_management-ip.ttp
	modified:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_cm_device.ttp
	new file:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_net_interface_all-properties.ttp
	new file:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_net_lldp-neighbors_all-properties.ttp
	deleted:    nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_cluster.ttp
	modified:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_hardware.ttp
	new file:   nautobot_device_onboarding/parsers/ttp/f5_tmsh_show_sys_version.ttp

<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #<ISSUE NUMBER GOES HERE>

## What's Changed

- adds support for Brocade/Ruckus fastiron
- adds support for HP Procurve.
- adds network data sync support for ArubaCX
- adds support for ArubaOS
- adds network data sync for F5 tmsh.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design:
 -- ntc templates submission for textfsm-dependent mappers -> (aruba os, aruba cx, hp procurve, fastiron).
