### PR TITLE
fix: handle no device primary ip in sync network data job

### DIFF
--- a/changes/428.fixed
+++ b/changes/428.fixed
@@ -1,0 +1,1 @@
+In the sync network data job, added handling of Devices who's Primary IP is not set.

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -82,7 +82,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
         """
         self.primary_ips = {}
         for device in device_queryset:
-            self.primary_ips[device.id] = device.primary_ip.id
+            self.primary_ips[device.id] = device.primary_ip.id if device.primary_ip else None
 
     def load_param_mac_address(self, parameter_name, database_object):
         """Convert interface mac_address to string."""

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -398,6 +398,9 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
         for device in self.job.devices_to_load.all():  # refresh queryset after sync is complete
             if not device.primary_ip:
                 ip_address = ""
+                if not self.primary_ips[device.id]:
+                    self.job.logger.info(f"No primary IP Address was assigned for Device: {device.name}.")
+                    continue
                 try:
                     ip_address = IPAddress.objects.get(id=self.primary_ips[device.id])
                     device.primary_ip4 = ip_address

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -399,7 +399,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
             if not device.primary_ip:
                 ip_address = ""
                 if not self.primary_ips[device.id]:
-                    self.job.logger.info(f"No primary IP Address was assigned for Device: {device.name}.")
+                    self.job.logger.info(f"No primary IP Address was previously assigned for Device: {device.name}.")
                     continue
                 try:
                     ip_address = IPAddress.objects.get(id=self.primary_ips[device.id])

--- a/nautobot_device_onboarding/tests/test_jobs.py
+++ b/nautobot_device_onboarding/tests/test_jobs.py
@@ -195,7 +195,7 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
     def test_sync_network_data__success(self, device_data):
         """Test a successful run of the 'Sync Network Data From Network' job"""
         device_data.return_value = sync_network_data_fixture.sync_network_mock_data_valid
-        devices = ["demo-cisco-1", "demo-cisco-2"]
+        devices = ["demo-cisco-1", "demo-cisco-2", "demo-cisco-4"]
         device_ids_to_sync = list(Device.objects.filter(name__in=devices).values_list("id", flat=True))
 
         job_form_inputs = {

--- a/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
@@ -293,7 +293,7 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
             device_queryset=self.job.devices_to_load
         )
         for device in self.job.devices_to_load:
-            self.assertEqual(self.sync_network_data_adapter.primary_ips[device.id], device.primary_ip.id)
+            self.assertEqual(self.sync_network_data_adapter.primary_ips[device.id], device.primary_ip.id if device.primary_ip else None)
 
     def test_load_param_mac_address(self):
         """Test MAC address string converstion."""
@@ -444,4 +444,4 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
             device.validated_save()
         self.sync_network_data_adapter.sync_complete(source=None, diff=None)
         for device in self.job.devices_to_load.all():
-            self.assertEqual(self.sync_network_data_adapter.primary_ips[device.id], device.primary_ip.id)
+            self.assertEqual(self.sync_network_data_adapter.primary_ips[device.id], device.primary_ip.id if device.primary_ip else None)

--- a/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
@@ -283,7 +283,7 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
         self.job.sync_vlans = True
         self.job.sync_vrfs = True
         self.job.debug = True
-        self.job.devices_to_load = Device.objects.filter(name__in=["demo-cisco-1", "demo-cisco-2"])
+        self.job.devices_to_load = Device.objects.filter(name__in=["demo-cisco-1", "demo-cisco-2", "demo-cisco-4"])
 
         self.sync_network_data_adapter = SyncNetworkDataNautobotAdapter(job=self.job, sync=None)
 

--- a/nautobot_device_onboarding/tests/utils.py
+++ b/nautobot_device_onboarding/tests/utils.py
@@ -74,6 +74,9 @@ def sync_network_data_ensure_required_nautobot_objects():
     ip_address_3, _ = IPAddress.objects.get_or_create(
         host="10.1.1.15", mask_length=24, type=IPAddressTypeChoices.TYPE_HOST, status=status
     )
+    ip_address_4, _ = IPAddress.objects.get_or_create(
+        host="10.1.1.16", mask_length=24, type=IPAddressTypeChoices.TYPE_HOST, status=status
+    )
     location_type, _ = LocationType.objects.get_or_create(name="Site")
     location_type.content_types.add(ContentType.objects.get_for_model(Device))
     location_type.content_types.add(ContentType.objects.get_for_model(VLAN))
@@ -134,6 +137,17 @@ def sync_network_data_ensure_required_nautobot_objects():
         secrets_group=secrets_group,
         software_version=software_version_2,
     )
+    device_4, _ = Device.objects.get_or_create(
+        name="demo-cisco-4",
+        serial="9ABUXU5884444",
+        device_type=device_type,
+        status=status,
+        location=location,
+        role=device_role,
+        platform=platform_2,
+        secrets_group=secrets_group,
+        software_version=software_version_2,
+    )
     interface_1, _ = Interface.objects.get_or_create(
         device=device_1, name="GigabitEthernet1", status=status, type=InterfaceTypeChoices.TYPE_VIRTUAL
     )
@@ -149,6 +163,9 @@ def sync_network_data_ensure_required_nautobot_objects():
     interface_4, _ = Interface.objects.get_or_create(
         device=device_1, name="GigabitEthernet2", status=status, type=InterfaceTypeChoices.TYPE_VIRTUAL
     )
+    interface_5, _ = Interface.objects.get_or_create(
+    device=device_4, name="GigabitEthernet2", status=status, type=InterfaceTypeChoices.TYPE_VIRTUAL
+    )
     IPAddressToInterface.objects.get_or_create(interface=interface_1, ip_address=ip_address_1)
     device_1.primary_ip4 = ip_address_1
     device_1.validated_save()
@@ -160,6 +177,9 @@ def sync_network_data_ensure_required_nautobot_objects():
     IPAddressToInterface.objects.get_or_create(interface=interface_3, ip_address=ip_address_3)
     device_3.primary_ip4 = ip_address_3
     device_3.validated_save()
+
+    # Don't set primary IP for Device 4
+    IPAddressToInterface.objects.get_or_create(interface=interface_5, ip_address=ip_address_4)
 
     provider_1, _ = Provider.objects.get_or_create(name="Provider 1")
     circuit_type_1, _ = CircuitType.objects.get_or_create(name="Circuit Type 1")
@@ -197,9 +217,11 @@ def sync_network_data_ensure_required_nautobot_objects():
     testing_objects["ip_address_1"] = ip_address_1
     testing_objects["ip_address_2"] = ip_address_2
     testing_objects["ip_address_3"] = ip_address_3
+    testing_objects["ip_address_4"] = ip_address_4
     testing_objects["device_1"] = device_1
     testing_objects["device_2"] = device_2
     testing_objects["device_3"] = device_3
+    testing_objects["device_4"] = device_4
     testing_objects["vlan_1"] = vlan_1
     testing_objects["vlan_2"] = vlan_2
     testing_objects["vrf_1"] = vrf_1


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #428 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

In the sync network data job, added handling of Devices who's Primary IP is not set.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
