### PR TITLE
Release v5.2.1

### DIFF
--- a/changes/500.fixed
+++ b/changes/500.fixed
@@ -1,1 +1,0 @@
-Fixed dryrun variable being set to True incorrectly.

--- a/changes/500.fixed
+++ b/changes/500.fixed
@@ -1,0 +1,1 @@
+Fixed dryrun variable being set to True incorrectly.

--- a/docs/admin/release_notes/version_5.2.md
+++ b/docs/admin/release_notes/version_5.2.md
@@ -7,6 +7,14 @@ This document describes all new features and changes in the release. The format 
 - Added support for assigning tenants to devices.
 
 <!-- towncrier release notes start -->
+
+
+## [v5.2.1 (2026-01-29)](https://github.com/nautobot/nautobot-app-device-onboarding/releases/tag/v5.2.1)
+
+### Fixed
+
+- [#500](https://github.com/nautobot/nautobot-app-device-onboarding/issues/500) - Fixed dryrun variable being set to True incorrectly.
+
 ## [v5.2.0 (2026-01-27)](https://github.com/nautobot/nautobot-app-device-onboarding/releases/tag/v5.2.0)
 
 ### Added

--- a/nautobot_device_onboarding/jobs.py
+++ b/nautobot_device_onboarding/jobs.py
@@ -580,7 +580,7 @@ class SSOTSyncDevices(DataSource):  # pylint: disable=too-many-instance-attribut
         if self.found_invalid_ip_address:
             raise RuntimeError("An invalid IP Address or FQDN was provided")
 
-        super().run(dryrun, memory_profiling)
+        super().run(dryrun=dryrun, memory_profiling=memory_profiling)
 
 
 class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attributes
@@ -760,7 +760,7 @@ class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attr
         else:
             self.logger.warning("Over 300 devices were selected to sync")
 
-        super().run(dryrun, memory_profiling)
+        super().run(dryrun=dryrun, memory_profiling=memory_profiling)
 
 
 class DeviceOnboardingTroubleshootingJob(Job):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-onboarding"
-version = "5.2.1a0"
+version = "5.2.1"
 description = "A app for Nautobot to easily onboard new devices."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-device-onboarding"
-version = "5.2.0"
+version = "5.2.1a0"
 description = "A app for Nautobot to easily onboard new devices."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v5.2.1 (2026-01-29)](https://github.com/nautobot/nautobot-app-device-onboarding/releases/tag/v5.2.1)

### Fixed

- [#500](https://github.com/nautobot/nautobot-app-device-onboarding/issues/500) - Fixed dryrun variable being set to True incorrectly.