### PR TITLE
Fixed VLAN sync failing with duplicate child location name.

### DIFF
--- a/changes/509.fixed
+++ b/changes/509.fixed
@@ -1,0 +1,1 @@
+Fixed VLAN sync failing with duplicate child location name.

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -153,7 +153,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
                 adapter=self,
                 name=vlan.name,
                 vid=vlan.vid,
-                location__name=vlan.location.name if vlan.location else "",
+                location_natural_key=vlan.location.natural_key(),
             )
             try:
                 network_vlan.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
@@ -661,9 +661,9 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
 
     def load_vlans(self):
         """Load vlans into the Diffsync store."""
-        location_names = {}
+        location_natural_keys = {}
         for device in self.job.devices_to_load:
-            location_names[device.name] = device.location.name
+            location_natural_keys[device.name] = device.location.natural_key()
 
         for (
             hostname,
@@ -679,7 +679,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                             adapter=self,
                             name=tagged_vlan["name"],
                             vid=tagged_vlan["id"],
-                            location__name=location_names.get(hostname, ""),
+                            location_natural_key=location_natural_keys[hostname],
                         )
                         self.add(network_vlan)
                     except diffsync.exceptions.ObjectAlreadyExists:
@@ -703,7 +703,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                             adapter=self,
                             name=interface_data["untagged_vlan"]["name"],
                             vid=interface_data["untagged_vlan"]["id"],
-                            location__name=location_names.get(hostname, ""),
+                            location_natural_key=location_natural_keys[hostname],
                         )
                         self.add(network_vlan)
                     except diffsync.exceptions.ObjectAlreadyExists:

--- a/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
+++ b/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
@@ -1,6 +1,6 @@
 """Diffsync models."""
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from uuid import UUID
 
 try:
@@ -208,28 +208,28 @@ class SyncNetworkDataVLAN(DiffSyncModel):
 
     _model = VLAN
     _modelname = "vlan"
-    _identifiers = ("vid", "name", "location__name")
+    _identifiers = ("vid", "name", "location_natural_key")
 
     vid: int
     name: str
-    location__name: str
+    location_natural_key: Optional[Tuple[str, ...]] = None
 
     @classmethod
     def create(cls, adapter, ids, attrs):
         """Create a new VLAN."""
         location = None
         try:
-            location = Location.objects.get(name=ids["location__name"])
+            location = Location.objects.get_by_natural_key(*ids["location_natural_key"])
         except ObjectDoesNotExist as err:
             adapter.job.logger.error(
                 f"While creating VLAN {ids['vid']} - {ids['name']}, "
-                f"unable to find a Location with name: {ids['location__name']}."
+                f"unable to find Location: {ids['location_natural_key']}."
             )
             raise diffsync_exceptions.ObjectNotCreated(err)
         except MultipleObjectsReturned as err:
             adapter.job.logger.error(
                 f"While creating VLAN {ids['vid']} - {ids['name']}, "
-                f"Multiple Locations were found with name: {ids['location__name']}."
+                f"Multiple Locations found: {ids['location_natural_key']}."
             )
             raise diffsync_exceptions.ObjectNotCreated(err)
         try:

--- a/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
@@ -131,20 +131,24 @@ class SyncNetworkDataNetworkAdapterTestCase(TransactionTestCase):
         self.job.devices_to_load = Device.objects.filter(name__in=["demo-cisco-1", "demo-cisco-2"])
         self.sync_network_data_adapter.load_vlans()
 
-        for _, device_data in self.job.command_getter_result.items():
+        location_natural_keys = {}
+        for device in self.job.devices_to_load:
+            location_natural_keys[device.name] = device.location.natural_key()
+
+        for hostname, device_data in self.job.command_getter_result.items():
             for _, interface_data in device_data["interfaces"].items():
                 for tagged_vlan in interface_data["tagged_vlans"]:
-                    unique_id = f"{tagged_vlan['id']}__{tagged_vlan['name']}__{self.job.location.name}"
+                    unique_id = f"{tagged_vlan['id']}__{tagged_vlan['name']}__{tuple(location_natural_keys[hostname])}"
                     diffsync_obj = self.sync_network_data_adapter.get("vlan", unique_id)
                     self.assertEqual(int(tagged_vlan["id"]), diffsync_obj.vid)
                     self.assertEqual(tagged_vlan["name"], diffsync_obj.name)
-                    self.assertEqual(self.job.location.name, diffsync_obj.location__name)
+                    self.assertEqual(tuple(location_natural_keys[hostname]), diffsync_obj.location_natural_key)
                 if interface_data["untagged_vlan"]:
-                    unique_id = f"{interface_data['untagged_vlan']['id']}__{interface_data['untagged_vlan']['name']}__{self.job.location.name}"
+                    unique_id = f"{interface_data['untagged_vlan']['id']}__{interface_data['untagged_vlan']['name']}__{tuple(location_natural_keys[hostname])}"
                     diffsync_obj = self.sync_network_data_adapter.get("vlan", unique_id)
                     self.assertEqual(int(interface_data["untagged_vlan"]["id"]), diffsync_obj.vid)
                     self.assertEqual(interface_data["untagged_vlan"]["name"], diffsync_obj.name)
-                    self.assertEqual(self.job.location.name, diffsync_obj.location__name)
+                    self.assertEqual(tuple(location_natural_keys[hostname]), diffsync_obj.location_natural_key)
 
     def test_load_vrfs(self):
         """Test loading vrf data returned from command getter into the diffsync store."""
@@ -327,11 +331,11 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
         self.sync_network_data_adapter.load_vlans()
 
         for vlan in VLAN.objects.all():
-            unique_id = f"{vlan.vid}__{vlan.name}__{self.job.location.name}"
+            unique_id = f"{vlan.vid}__{vlan.name}__{tuple(vlan.location.natural_key())}"
             diffsync_obj = self.sync_network_data_adapter.get("vlan", unique_id)
             self.assertEqual(int(vlan.vid), diffsync_obj.vid)
             self.assertEqual(vlan.name, diffsync_obj.name)
-            self.assertEqual(self.job.location.name, diffsync_obj.location__name)
+            self.assertEqual(tuple(vlan.location.natural_key()), diffsync_obj.location_natural_key)
 
     def test_load_tagged_vlans_to_interface(self):
         """Test loading Nautobot tagged vlan interface assignments into the Diffsync store."""


### PR DESCRIPTION
# Closes: #509 

## What's Changed
* Adjusted `SyncNetworkDataVLAN` to use `location_natural_key` instead of `location__name` in `_identifiers`.
* Adjusted code that makes use of `SyncNetworkDataVLAN` to match.
* Adjusted tests for `SyncNetworkDataVLAN` to match.
## Before
`While creating VLAN 1234 - foo, Multiple Locations were found with name: ChildLocationA.`
## After
No error.
## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests