### PR TITLE
Fail Job When One or More Tasks Fail -  ltm

### DIFF
--- a/changes/517.fixed
+++ b/changes/517.fixed
@@ -1,0 +1,1 @@
+Added “fail job on task failure” so the job fails when one or more tasks fail.

--- a/nautobot_device_onboarding/jobs.py
+++ b/nautobot_device_onboarding/jobs.py
@@ -343,6 +343,11 @@ class SSOTSyncDevices(DataSource):  # pylint: disable=too-many-instance-attribut
         required=False,
         description="Tenant to be applied to all synced devices.",
     )
+    fail_job_on_task_failure = BooleanVar(
+        description="If any tasks for any device fails, fail the entire job result.",
+        required=False,
+        default=False,
+    )
 
     template_name = "nautobot_device_onboarding/ssot_sync_devices.html"
 
@@ -514,11 +519,13 @@ class SSOTSyncDevices(DataSource):  # pylint: disable=too-many-instance-attribut
         ip_address_status=None,
         secrets_group=None,
         platform=None,
+        fail_job_on_task_failure=None,
     ):
         """Run sync."""
         self.dryrun = dryrun
         self.memory_profiling = memory_profiling
         self.debug = debug
+        self.fail_job_on_task_failure = fail_job_on_task_failure
 
         if csv_file:
             self.ip_address_inventory = self._process_csv_data(csv_file=csv_file)
@@ -655,6 +662,11 @@ class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attr
         required=False,
         description="Only update devices with the selected platform.",
     )
+    fail_job_on_task_failure = BooleanVar(
+        description="If any tasks for any device fails, fail the entire job result.",
+        required=False,
+        default=False,
+    )
 
     def load_source_adapter(self):
         """Load network data adapter."""
@@ -686,6 +698,7 @@ class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attr
         location=None,
         device_role=None,
         platform=None,
+        fail_job_on_task_failure=None,
     ):
         """Run sync."""
         self.dryrun = dryrun
@@ -704,6 +717,7 @@ class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attr
         self.location = location
         self.device_role = device_role
         self.platform = platform
+        self.fail_job_on_task_failure = fail_job_on_task_failure
 
         # Check for last_network_data_sync CustomField
         if self.debug:

--- a/nautobot_device_onboarding/nornir_plays/command_getter.py
+++ b/nautobot_device_onboarding/nornir_plays/command_getter.py
@@ -170,6 +170,8 @@ def netmiko_send_commands(task: Task, command_getter_yaml_data: Dict, command_ge
                     if "Invalid input detected at" in current_result.result:
                         task.results[result_idx].result = []
                         task.results[result_idx].failed = False
+                        if nautobot_job.fail_job_on_task_failure:
+                            task.results[result_idx].failed = True
                     else:
                         if command["parser"] == "textfsm":
                             try:
@@ -198,6 +200,10 @@ def netmiko_send_commands(task: Task, command_getter_yaml_data: Dict, command_ge
                                 task.results[result_idx].result = parsed_output
                                 task.results[result_idx].failed = False
                             except Exception:  # https://github.com/networktocode/ntc-templates/issues/369
+                                if nautobot_job.fail_job_on_task_failure:
+                                    task.results[result_idx].result = []
+                                    task.results[result_idx].failed = True
+                                    raise
                                 try:
                                     if nautobot_job.debug:
                                         traceback_str = traceback.format_exc().replace("\n", "<br>")
@@ -226,6 +232,10 @@ def netmiko_send_commands(task: Task, command_getter_yaml_data: Dict, command_ge
                                 task.results[result_idx].result = json.loads(parsed_result)
                                 task.results[result_idx].failed = False
                             except Exception:
+                                if nautobot_job.fail_job_on_task_failure:
+                                    task.results[result_idx].result = []
+                                    task.results[result_idx].failed = True
+                                    raise
                                 task.results[result_idx].result = []
                                 task.results[result_idx].failed = False
             else:
@@ -239,8 +249,16 @@ def netmiko_send_commands(task: Task, command_getter_yaml_data: Dict, command_ge
                         task.results[result_idx].result = jsonified
                         task.results[result_idx].failed = False
                     except Exception:
+                        if nautobot_job.fail_job_on_task_failure:
+                            task.results[result_idx].result = []
+                            task.results[result_idx].failed = True
+                            raise
                         task.result.failed = False
         except NornirSubTaskError:
+            if nautobot_job.fail_job_on_task_failure:
+                task.results[result_idx].result = []
+                task.results[result_idx].failed = True
+                raise
             # These exceptions indicate that the device is unreachable or the credentials are incorrect.
             # We should fail the task early to avoid trying all commands on a device that is unreachable.
             if type(task.results[result_idx].exception).__name__ == "NetmikoAuthenticationException":
@@ -321,14 +339,18 @@ def sync_devices_command_getter(job, log_level):
                         )
                         continue
                 nr_with_processors.inventory.hosts.update(single_host_inventory_constructed)
-            nr_with_processors.run(
+            result = nr_with_processors.run(
                 task=netmiko_send_commands,
                 command_getter_yaml_data=nr_with_processors.inventory.defaults.data["platform_parsing_info"],
                 command_getter_job="sync_devices",
                 logger=logger,
                 nautobot_job=job,
             )
+            if job.fail_job_on_task_failure and result.failed:
+                raise RuntimeError(f"netmiko_send_commads task failed with {result.failed_hosts.items()}.")
     except Exception as err:  # pylint: disable=broad-exception-caught
+        if job.fail_job_on_task_failure:
+            raise RuntimeError("Error During Sync Devices Command Getter.") from err
         try:
             if job.debug:
                 traceback_str = format_log_message(traceback.format_exc())
@@ -369,13 +391,17 @@ def sync_network_data_command_getter(job, log_level):
             },
         ) as nornir_obj:
             nr_with_processors = nornir_obj.with_processors([CommandGetterProcessor(logger, compiled_results, job)])
-            nr_with_processors.run(
+            result = nr_with_processors.run(
                 task=netmiko_send_commands,
                 command_getter_yaml_data=nr_with_processors.inventory.defaults.data["platform_parsing_info"],
                 command_getter_job="sync_network_data",
                 logger=logger,
                 nautobot_job=job,
             )
-    except Exception:  # pylint: disable=broad-exception-caught
+            if job.fail_job_on_task_failure and result.failed:
+                raise RuntimeError(f"netmiko_send_commads task failed with {result.failed_hosts.items()}.")
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        if job.fail_job_on_task_failure:
+            raise RuntimeError("Error During Sync Network Data Command Getter.") from err
         logger.info(f"Error During Sync Network Data Command Getter: {traceback.format_exc()}")
     return compiled_results

--- a/nautobot_device_onboarding/tests/test_jobs.py
+++ b/nautobot_device_onboarding/tests/test_jobs.py
@@ -57,6 +57,7 @@ class SSOTSyncDevicesTestCase(TransactionTestCase):
             "secrets_group": self.testing_objects["secrets_group"].pk,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         job_result = create_job_result_and_run_job(
             module="nautobot_device_onboarding.jobs", name="SSOTSyncDevices", **job_form_inputs
@@ -159,11 +160,13 @@ class SSOTSyncDevicesTestCase(TransactionTestCase):
             "update_devices_without_primary_ip": None,
             "device_role": None,
             "device_status": None,
+            "device_tenant": None,
             "interface_status": None,
             "ip_address_status": None,
             "secrets_group": None,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
 
         create_job_result_and_run_job(
@@ -216,6 +219,7 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
             "device_role": None,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         job_result = create_job_result_and_run_job(
             module="nautobot_device_onboarding.jobs", name="SSOTSyncNetworkData", **job_form_inputs
@@ -273,12 +277,14 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
             "update_devices_without_primary_ip": True,
             "device_role": self.testing_objects["device_role"].pk,
             "device_status": self.testing_objects["status"].pk,
+            "device_tenant": None,
             "interface_status": self.testing_objects["status"].pk,
             "ip_address_status": self.testing_objects["status"].pk,
             "default_prefix_status": self.testing_objects["status"].pk,
             "secrets_group": self.testing_objects["secrets_group"].pk,
             "platform": self.testing_objects["platform_1"].pk,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         current_file_path = os.path.dirname(os.path.abspath(__file__))
         fake_ios_inventory = {
@@ -334,11 +340,13 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
             "device_role": self.testing_objects["device_role"].pk,
             "device_status": self.testing_objects["status"].pk,
             "interface_status": self.testing_objects["status"].pk,
+            "device_tenant": None,
             "ip_address_status": self.testing_objects["status"].pk,
             "default_prefix_status": self.testing_objects["status"].pk,
             "secrets_group": self.testing_objects["secrets_group"].pk,
             "platform": self.testing_objects["platform_3"].pk,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         sync_network_data_job_form_inputs = {
             "debug": False,
@@ -356,6 +364,7 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
             "device_role": None,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
 
         initial_vlans = set(VLAN.objects.values_list("vid", flat=True))
@@ -447,12 +456,14 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
             "update_devices_without_primary_ip": True,
             "device_role": self.testing_objects["device_role"].pk,
             "device_status": self.testing_objects["status"].pk,
+            "device_tenant": None,
             "interface_status": self.testing_objects["status"].pk,
             "ip_address_status": self.testing_objects["status"].pk,
             "default_prefix_status": self.testing_objects["status"].pk,
             "secrets_group": self.testing_objects["secrets_group"].pk,
             "platform": self.testing_objects["platform_2"].pk,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         sync_network_data_job_form_inputs = {
             "debug": False,
@@ -470,6 +481,7 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
             "device_role": None,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
 
         initial_vrfs = set(VRF.objects.values_list("name", flat=True))

--- a/nautobot_device_onboarding/tests/test_sync_devices_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_devices_adapters.py
@@ -1,6 +1,7 @@
 """Test Cisco Support adapter."""
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from diffsync.exceptions import ObjectNotFound
 from nautobot.apps.testing import TransactionTestCase
@@ -12,6 +13,7 @@ from nautobot_device_onboarding.diffsync.adapters.sync_devices_adapters import (
     SyncDevicesNetworkAdapter,
 )
 from nautobot_device_onboarding.jobs import SSOTSyncDevices
+from nautobot_device_onboarding.nornir_plays.command_getter import sync_devices_command_getter
 from nautobot_device_onboarding.tests import utils
 from nautobot_device_onboarding.tests.fixtures import sync_devices_fixture
 
@@ -80,6 +82,42 @@ class SyncDevicesNetworkAdapterTestCase(TransactionTestCase):
             self.assertEqual([data["mgmt_interface"]], diffsync_device.interfaces)
             self.assertEqual(data["mask_length"], diffsync_device.mask_length)
             self.assertEqual(data["serial"], diffsync_device.serial)
+
+    @patch("nautobot_device_onboarding.nornir_plays.command_getter.InitNornir")
+    def test_command_getter_raises_when_fail_job_on_task_failure_true(self, init_nornir):
+        self.job.fail_job_on_task_failure = True
+
+        nornir_obj = MagicMock()
+        nr_with_processors = MagicMock()
+        nornir_obj.with_processors.return_value = nr_with_processors
+
+        nr_with_processors.run.return_value = SimpleNamespace(
+            failed=True,
+            failed_hosts={"1.1.1.1": "DEVICE01"},
+        )
+
+        init_nornir.return_value.__enter__.return_value = nornir_obj
+
+        with self.assertRaises(RuntimeError):
+            sync_devices_command_getter(job=self.job, log_level="INFO")
+
+    @patch("nautobot_device_onboarding.nornir_plays.command_getter.InitNornir")
+    def test_command_getter_does_not_raise_when_fail_job_on_task_failure_false(self, init_nornir):
+        self.job.fail_job_on_task_failure = False
+
+        nornir_obj = MagicMock()
+        nr_with_processors = MagicMock()
+        nornir_obj.with_processors.return_value = nr_with_processors
+
+        nr_with_processors.run.return_value = SimpleNamespace(
+            failed=True,
+            failed_hosts={"1.1.1.1": "DEVICE01"},
+        )
+
+        init_nornir.return_value.__enter__.return_value = nornir_obj
+
+        result = sync_devices_command_getter(job=self.job, log_level="INFO")
+        self.assertEqual(result, {})
 
 
 class SyncDevicesNautobotAdapterTestCase(TransactionTestCase):

--- a/nautobot_device_onboarding/tests/test_sync_devices_models.py
+++ b/nautobot_device_onboarding/tests/test_sync_devices_models.py
@@ -45,6 +45,7 @@ class SyncDevicesDeviceTestCase(TransactionTestCase):
             "secrets_group": self.testing_objects["secrets_group_alternate"].pk,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         self.testing_objects["device_1"].primary_ip4 = None  # test existing device with missing primary ip
         self.testing_objects["device_1"].validated_save()
@@ -98,6 +99,7 @@ class SyncDevicesDeviceTestCase(TransactionTestCase):
             "secrets_group": self.testing_objects["secrets_group"].pk,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         job_result = create_job_result_and_run_job(
             module="nautobot_device_onboarding.jobs", name="SSOTSyncDevices", **job_form_inputs
@@ -146,6 +148,7 @@ class SyncDevicesDeviceTestCase(TransactionTestCase):
             "secrets_group": self.testing_objects["secrets_group_alternate"].pk,
             "platform": None,
             "memory_profiling": False,
+            "fail_job_on_task_failure": False,
         }
         job_result = create_job_result_and_run_job(
             module="nautobot_device_onboarding.jobs", name="SSOTSyncDevices", **job_form_inputs


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #517

## What's Changed

Currently, in nautobot-app-device-onboarding, a Job may be marked as Completed even if one or more internal tasks fail during execution. This can lead to confusion, especially when the job is part of a larger workflow or automation process.

We would like to implement a “fail job on task failure” behavior similar to what is done in [nautobot-app-golden-config](https://github.com/nautobot/nautobot-app-golden-config/blob/19d0d9825fb7f7f052bd81b24fb2145121e71867/nautobot_golden_config/jobs.py#L563-L564).

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
