### PR TITLE
Arista EOS virtual/secondary IPs

### DIFF
--- a/changes/523.fixed
+++ b/changes/523.fixed
@@ -1,0 +1,1 @@
+Fixed invalid IP Address returned for Arista EOS virtual interface addresses.

--- a/nautobot_device_onboarding/command_mappers/arista_eos.yml
+++ b/nautobot_device_onboarding/command_mappers/arista_eos.yml
@@ -57,7 +57,13 @@ sync_network_data:
     commands:
       - command: "show interfaces | json"
         parser: "none"
-        jpath: 'interfaces."{{ current_key }}".interfaceAddress[].[{ip_address: primaryIp.address, prefix_length: primaryIp.maskLen }][]'  # yamllint disable-line rule:quoted-strings
+        jpath: >-
+          interfaces."{{ current_key }}".interfaceAddress[]
+          .[primaryIp, virtualIp, secondaryIps.*][] []
+          | [?address != '0.0.0.0'].{
+              ip_address: address,
+              prefix_length: maskLen
+          }
         post_processor: "{{ obj | tojson }}"
   interfaces__mtu:
     commands:

--- a/nautobot_device_onboarding/tests/mock/arista_eos/command_getter_result_1.json
+++ b/nautobot_device_onboarding/tests/mock/arista_eos/command_getter_result_1.json
@@ -95,6 +95,59 @@
                 "maxMssIngress": 0,
                 "maxMssEgress": 0
             },
+            "Ethernet5": {
+                "name": "Ethernet5",
+                "lineProtocolStatus": "up",
+                "interfaceStatus": "disabled",
+                "mtu": "1500",
+                "interfaceAddressBrief": {
+                    "ipAddr": {
+                        "address": "5.5.5.5",
+                        "maskLen": 24
+                    }
+                },
+                "ipv4Routable240": false,
+                "ipv4Routable0": false,
+                "enabled": true,
+                "description": "",
+                "interfaceAddress": {
+                    "primaryIp": {
+                        "address": "5.5.5.5",
+                        "maskLen": 24
+                    },
+                    "secondaryIps": {},
+                    "secondaryIpsOrderedList": [
+                        {
+                            "address": "2.2.2.3",
+                            "maskLen": 24
+                        },
+                        {
+                            "address": "2.3.3.4",
+                            "maskLen": 24
+                        }
+                    ],
+                    "virtualIp": {
+                        "address": "5.5.6.6",
+                        "maskLen": 24
+                    },
+                    "virtualSecondaryIps": {},
+                    "virtualSecondaryIpsOrderedList": [],
+                    "broadcastAddress": "255.255.255.255",
+                    "dhcp": false
+                },
+                "proxyArp": false,
+                "proxyArpAllowDefault": false,
+                "localProxyArp": false,
+                "gratuitousArp": false,
+                "routedAddr": "52:54:00:91:1e:bf",
+                "isVrrpBackup": false,
+                "vrf": "default",
+                "urpf": "disable",
+                "addresslessForwarding": "isInvalid",
+                "directedBroadcastEnabled": false,
+                "maxMssIngress": 0,
+                "maxMssEgress": 0
+            },
             "Management1": {
                 "name": "Management1",
                 "lineProtocolStatus": "up",
@@ -410,6 +463,99 @@
                 "mtu": "1500",
                 "name": "Ethernet4",
                 "physicalAddress": "52:54:00:91:1e:bf"
+            },
+            "Ethernet5": {
+                "autoNegotiate": "unknown",
+                "bandwidth": 1000000000,
+                "description": "",
+                "duplex": "duplexFull",
+                "forwardingModel": "routed",
+                "hardware": "ethernet",
+                "interfaceAddress": [
+                    {
+                        "broadcastAddress": "255.255.255.255",
+                        "dhcp": false,
+                        "primaryIp": {
+                            "address": "5.5.5.5",
+                            "maskLen": 24
+                        },
+                        "secondaryIps": {
+                            "2.2.2.3": {
+                                "address": "2.2.2.3",
+                                "maskLen": 24
+                            },
+                            "2.3.3.4": {
+                                "address": "2.3.3.4",
+                                "maskLen": 24
+                            }
+                        },
+                        "secondaryIpsOrderedList": [
+                            {
+                                "address": "2.2.2.3",
+                                "maskLen": 24
+                            },
+                            {
+                                "address": "2.3.3.4",
+                                "maskLen": 24
+                            }
+                        ],
+                        "virtualIp": {
+                            "address": "5.5.6.6",
+                            "maskLen": 24
+                        },
+                        "virtualSecondaryIps": {},
+                        "virtualSecondaryIpsOrderedList": []
+                    }
+                ],
+                "interfaceCounters": {
+                    "counterRefreshTime": 1716995214.376519,
+                    "inBroadcastPkts": 0,
+                    "inDiscards": 0,
+                    "inMulticastPkts": 0,
+                    "inOctets": 0,
+                    "inTotalPkts": 0,
+                    "inUcastPkts": 0,
+                    "inputErrorsDetail": {
+                        "alignmentErrors": 0,
+                        "fcsErrors": 0,
+                        "giantFrames": 0,
+                        "runtFrames": 0,
+                        "rxPause": 0,
+                        "symbolErrors": 0
+                    },
+                    "linkStatusChanges": 2,
+                    "outBroadcastPkts": 0,
+                    "outDiscards": 0,
+                    "outMulticastPkts": 20,
+                    "outOctets": 3119,
+                    "outTotalPkts": 20,
+                    "outUcastPkts": 0,
+                    "outputErrorsDetail": {
+                        "collisions": 0,
+                        "deferredTransmissions": 0,
+                        "lateCollisions": 0,
+                        "txPause": 0
+                    },
+                    "totalInErrors": 0,
+                    "totalOutErrors": 0
+                },
+                "interfaceStatistics": {
+                    "inBitsRate": 0.0,
+                    "inPktsRate": 0.0,
+                    "outBitsRate": 37.37829217160852,
+                    "outPktsRate": 0.0288879875526965,
+                    "updateInterval": 300.0
+                },
+                "interfaceStatus": "connected",
+                "l2Mru": 0,
+                "l3MtuConfigured": false,
+                "lanes": 0,
+                "lastStatusChangeTimestamp": 1716994739.7757108,
+                "lineProtocolStatus": "up",
+                "loopbackMode": "loopbackNone",
+                "mtu": "1500",
+                "name": "Ethernet5",
+                "physicalAddress": "52:54:00:91:1e:bb"
             },
             "Management1": {
                 "autoNegotiate": "success",

--- a/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_no_options/expected_result_1.json
+++ b/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_no_options/expected_result_1.json
@@ -38,15 +38,37 @@
         "Ethernet4": {
             "802.1Q_mode": "tagged",
             "description": "",
+            "ip_addresses": [],
+            "lag": [],
+            "link_status": "True",
+            "mac_address": "52:54:00:91:1e:bf",
+            "mtu": "1500",
+            "type": "1000base-t"
+        },
+        "Ethernet5": {
+            "802.1Q_mode": "",
+            "description": "",
             "ip_addresses": [
                 {
-                    "ip_address": "0.0.0.0",
-                    "prefix_length": 0
+                    "ip_address": "5.5.5.5",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "5.5.6.6",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.2.2.3",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.3.3.4",
+                    "prefix_length": 24
                 }
             ],
             "lag": [],
             "link_status": "True",
-            "mac_address": "52:54:00:91:1e:bf",
+            "mac_address": "52:54:00:91:1e:bb",
             "mtu": "1500",
             "type": "1000base-t"
         },

--- a/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_with_software/expected_result_1.json
+++ b/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_with_software/expected_result_1.json
@@ -38,15 +38,37 @@
         "Ethernet4": {
             "802.1Q_mode": "tagged",
             "description": "",
+            "ip_addresses": [],
+            "lag": [],
+            "link_status": "True",
+            "mac_address": "52:54:00:91:1e:bf",
+            "mtu": "1500",
+            "type": "1000base-t"
+        },
+        "Ethernet5": {
+            "802.1Q_mode": "",
+            "description": "",
             "ip_addresses": [
                 {
-                    "ip_address": "0.0.0.0",
-                    "prefix_length": 0
+                    "ip_address": "5.5.5.5",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "5.5.6.6",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.2.2.3",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.3.3.4",
+                    "prefix_length": 24
                 }
             ],
             "lag": [],
             "link_status": "True",
-            "mac_address": "52:54:00:91:1e:bf",
+            "mac_address": "52:54:00:91:1e:bb",
             "mtu": "1500",
             "type": "1000base-t"
         },

--- a/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_with_vlans/expected_result_1.json
+++ b/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_with_vlans/expected_result_1.json
@@ -50,12 +50,7 @@
         "Ethernet4": {
             "802.1Q_mode": "tagged",
             "description": "",
-            "ip_addresses": [
-                {
-                    "ip_address": "0.0.0.0",
-                    "prefix_length": 0
-                }
-            ],
+            "ip_addresses": [],
             "lag": [],
             "link_status": "True",
             "mac_address": "52:54:00:91:1e:bf",
@@ -71,6 +66,35 @@
                 "id": 1,
                 "name": "default"
             }
+        },
+        "Ethernet5": {
+            "802.1Q_mode": "",
+            "description": "",
+            "ip_addresses": [
+                {
+                    "ip_address": "5.5.5.5",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "5.5.6.6",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.2.2.3",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.3.3.4",
+                    "prefix_length": 24
+                }
+            ],
+            "lag": [],
+            "link_status": "True",
+            "mac_address": "52:54:00:91:1e:bb",
+            "mtu": "1500",
+            "tagged_vlans": [],
+            "type": "1000base-t",
+            "untagged_vlan": {}
         },
         "Management1": {
             "802.1Q_mode": "",

--- a/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_with_vrfs/expected_result_1.json
+++ b/nautobot_device_onboarding/tests/mock/arista_eos/sync_network_data_with_vrfs/expected_result_1.json
@@ -43,12 +43,7 @@
         "Ethernet4": {
             "802.1Q_mode": "tagged",
             "description": "",
-            "ip_addresses": [
-                {
-                    "ip_address": "0.0.0.0",
-                    "prefix_length": 0
-                }
-            ],
+            "ip_addresses": [],
             "lag": [],
             "link_status": "True",
             "mac_address": "52:54:00:91:1e:bf",
@@ -56,6 +51,36 @@
             "type": "1000base-t",
             "vrf": {
                 "name": "jeff"
+            }
+        },
+        "Ethernet5": {
+            "802.1Q_mode": "",
+            "description": "",
+            "ip_addresses": [
+                {
+                    "ip_address": "5.5.5.5",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "5.5.6.6",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.2.2.3",
+                    "prefix_length": 24
+                },
+                {
+                    "ip_address": "2.3.3.4",
+                    "prefix_length": 24
+                }
+            ],
+            "lag": [],
+            "link_status": "True",
+            "mac_address": "52:54:00:91:1e:bb",
+            "mtu": "1500",
+            "type": "1000base-t",
+            "vrf": {
+                "name": "default"
             }
         },
         "Management1": {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #523
## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This PR modifies the command_mapper for arista_eos, specifically for IP Address to Interface mappings. The new JMESPath will ignore any IP Address that equals '0.0.0.0', as Arista will only display this if the field is empty/non-existent. It searches for any Primary, Secondary, or Virtual address, and will add any that exist (allows for multiple per Interface).
Tests added to support this new functionality.


## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example (in tests)
- [x] Unit, Integration Tests
