### PR TITLE
Improve debug-level logging

### DIFF
--- a/changes/409.fixed
+++ b/changes/409.fixed
@@ -1,1 +1,1 @@
-Improve debug-level logging.
+Fixed debug logging not adhering to the debug job input boolean.

--- a/changes/409.fixed
+++ b/changes/409.fixed
@@ -1,0 +1,1 @@
+Improve debug-level logging.

--- a/nautobot_device_onboarding/nornir_plays/command_getter.py
+++ b/nautobot_device_onboarding/nornir_plays/command_getter.py
@@ -149,8 +149,8 @@ def netmiko_send_commands(task: Task, command_getter_yaml_data: Dict, command_ge
         logger.error(
             f"{task.host.platform} has missing definitions for cables in command_mapper YAML file. Cables will not be loaded."
         )
-
-    logger.debug(f"Commands to run: {[cmd['command'] for cmd in commands]}")
+    if nautobot_job.debug:
+        logger.debug(f"Commands to run: {[cmd['command'] for cmd in commands]}")
     # All commands in this for loop are running within 1 device connection.
     for result_idx, command in enumerate(commands):
         send_command_kwargs = {}
@@ -179,9 +179,10 @@ def netmiko_send_commands(task: Task, command_getter_yaml_data: Dict, command_ge
                                 git_template_dir = get_git_repo_parser_path(parser_type="textfsm")
                                 if git_template_dir:
                                     if not check_for_required_file(git_template_dir, "index"):
-                                        logger.debug(
-                                            f"Unable to find required index file in {git_template_dir} for textfsm parsing. Falling back to default templates."
-                                        )
+                                        if nautobot_job.debug:
+                                            logger.debug(
+                                                f"Unable to find required index file in {git_template_dir} for textfsm parsing. Falling back to default templates."
+                                            )
                                         git_template_dir = None
                                 # Parsing textfsm ourselves instead of using netmikos use_<parser> function to be able to handle exceptions
                                 # ourselves. Default for netmiko is if it can't parse to return raw text which is tougher to handle.

--- a/nautobot_device_onboarding/nornir_plays/formatter.py
+++ b/nautobot_device_onboarding/nornir_plays/formatter.py
@@ -91,16 +91,19 @@ def extract_and_post_process(parsed_command_output, yaml_command_element, j2_dat
     # This just renders the jpath itself if any interpolation is needed.
     jpath_template = j2_env.from_string(yaml_command_element["jpath"])
     j2_rendered_jpath = jpath_template.render(**j2_data_context)
-    logger.debug("Post Rendered Jpath: %s", j2_rendered_jpath)
+    if job_debug:
+        logger.debug("Post Rendered Jpath: %s", j2_rendered_jpath)
     try:
         if isinstance(parsed_command_output, str):
             try:
                 parsed_command_output = json.loads(parsed_command_output)
             except (JSONDecodeError, TypeError):
-                logger.debug("Parsed Command Output is a string but not jsonable: %s", parsed_command_output)
+                if job_debug:
+                    logger.debug("Parsed Command Output is a string but not jsonable: %s", parsed_command_output)
         extracted_value = extract_data_from_json(parsed_command_output, j2_rendered_jpath)
     except TypeError as err:
-        logger.debug("Error occurred during extraction: %s setting default extracted value to []", err)
+        if job_debug:
+            logger.debug("Error occurred during extraction: %s setting default extracted value to []", err)
         extracted_value = []
     pre_processed_extracted = extracted_value
     if yaml_command_element.get("post_processor"):
@@ -116,8 +119,9 @@ def extract_and_post_process(parsed_command_output, yaml_command_element, j2_dat
     else:
         extracted_processed = extracted_value
     post_processed_data = normalize_processed_data(extracted_processed, iter_type)
-    logger.debug("Pre Processed Extracted: %s", pre_processed_extracted)
-    logger.debug("Post Processed Data: %s", post_processed_data)
+    if job_debug:
+        logger.debug("Pre Processed Extracted: %s", pre_processed_extracted)
+        logger.debug("Post Processed Data: %s", post_processed_data)
     return pre_processed_extracted, post_processed_data
 
 

--- a/nautobot_device_onboarding/nornir_plays/processor.py
+++ b/nautobot_device_onboarding/nornir_plays/processor.py
@@ -43,10 +43,11 @@ class CommandGetterProcessor(BaseLoggingProcessor):
             None
         """
         parsed_command_outputs = {}
-        self.logger.info(
-            f"Task instance completed. Task Name: {task.name}",
-            extra={"object": task.host},
-        )
+        if self.job.debug:
+            self.logger.debug(
+                f"Task instance completed. Task Name: {task.name}",
+                extra={"object": task.host},
+            )
         # If any main task resulted in a failed:True then add that key so ssot side can ignore that entry.
         if result[0].failed:
             self.logger.info(
@@ -91,10 +92,11 @@ class CommandGetterProcessor(BaseLoggingProcessor):
 
     def subtask_instance_completed(self, task: Task, host: Host, result: MultiResult) -> None:
         """Processor for logging and data processing on subtask completed."""
-        self.logger.info(
-            f"Subtask {'failed' if result.failed else 'succeeded'}: {task.name}, {task.host}.",
-            extra={"object": task.host},
-        )
+        if self.job.debug:
+            self.logger.info(
+                f"Subtask {'failed' if result.failed else 'succeeded'}: {task.name}, {task.host}.",
+                extra={"object": task.host},
+            )
         if result.failed:
             for res in result:
                 if res.exception:
@@ -105,7 +107,8 @@ class CommandGetterProcessor(BaseLoggingProcessor):
 
     def subtask_instance_started(self, task: Task, host: Host) -> None:  # show command start
         """Processor for logging and data processing on subtask start."""
-        self.logger.info(f"Subtask starting: {task.name}, {task.host}.", extra={"object": task.host})
+        if self.job.debug:
+            self.logger.info(f"Subtask starting: {task.name}, {task.host}.", extra={"object": task.host})
 
 
 class TroubleshootingProcessor(BaseLoggingProcessor):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #409

## What's Changed

This PR addresses the “too chatty” logging behavior described in issue #409. To resolve this, I added checks to ensure that debug logs are only emitted when the debug job input variable is enabled, where this was previously missing. I also changed some INFO-level logs to DEBUG-level logs in the CommandGetterProcessor.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
