### PR TITLE
Fix Palo Manufacturer name and Platform override

### DIFF
--- a/changes/555.fixed
+++ b/changes/555.fixed
@@ -1,0 +1,1 @@
+Fixed erroneous Manufacturer (Paloalto) created, and Duplicate DeviceType exception when the same model exists under multiple manufacturers.

--- a/nautobot_device_onboarding/constants.py
+++ b/nautobot_device_onboarding/constants.py
@@ -57,3 +57,9 @@ ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER = "onboarding_command_mappers"
 
 # Support 4 modules deep (device -> modulebay -> module -> modulebay -> module -> modulebay -> module -> modulebay -> module -> interface)
 ONBOARDING_DEVICE_MODULE_RECURSION_LIMIT = 4
+
+# Network driver -> Nautobot Manufacturer display name. Override only where
+# `token.split("_")[0].title()` would produce the wrong canonical name.
+NETWORK_DRIVER_TO_MANUFACTURER = {
+    "paloalto_panos": "Palo Alto",
+}

--- a/nautobot_device_onboarding/diffsync/adapters/sync_devices_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_devices_adapters.py
@@ -119,6 +119,7 @@ class SyncDevicesNautobotAdapter(diffsync.Adapter):
                 adapter=self,
                 pk=device.pk,
                 device_type__model=device.device_type.model,
+                device_type__manufacturer__name=device.device_type.manufacturer.name,
                 location__name=device.location.name,
                 name=device.name,
                 platform__name=device.platform.name if device.platform else "",
@@ -211,10 +212,13 @@ class SyncDevicesNetworkAdapter(diffsync.Adapter):
                 self.job.logger.debug(f"loading manufacturer data for {ip_address}")
             onboarding_manufacturer = None
             try:
-                onboarding_manufacturer = self.manufacturer(
-                    adapter=self,
-                    name=self.device_data[ip_address]["manufacturer"],
+                form_platform = self.job.ip_address_inventory[ip_address].get("platform")
+                manufacturer_name = (
+                    form_platform.manufacturer.name
+                    if form_platform and form_platform.manufacturer
+                    else self.device_data[ip_address]["manufacturer"]
                 )
+                onboarding_manufacturer = self.manufacturer(adapter=self, name=manufacturer_name)
             except KeyError as err:
                 self.job.logger.error(
                     f"{ip_address}: Unable to load Manufacturer due to a missing key in returned data, {err.args}"
@@ -232,11 +236,24 @@ class SyncDevicesNetworkAdapter(diffsync.Adapter):
                 self.job.logger.debug(f"loading platform data for {ip_address}")
             onboarding_platform = None
             try:
+                form_platform = self.job.ip_address_inventory[ip_address].get("platform")
+                if form_platform:
+                    name = form_platform.name
+                    manufacturer_name = (
+                        form_platform.manufacturer.name
+                        if form_platform.manufacturer
+                        else self.device_data[ip_address]["manufacturer"]
+                    )
+                    network_driver = form_platform.network_driver or self.device_data[ip_address]["network_driver"]
+                else:
+                    name = self.device_data[ip_address]["platform"]
+                    manufacturer_name = self.device_data[ip_address]["manufacturer"]
+                    network_driver = self.device_data[ip_address]["network_driver"]
                 onboarding_platform = self.platform(
                     adapter=self,
-                    name=self.device_data[ip_address]["platform"],
-                    manufacturer__name=self.device_data[ip_address]["manufacturer"],
-                    network_driver=self.device_data[ip_address]["network_driver"],
+                    name=name,
+                    manufacturer__name=manufacturer_name,
+                    network_driver=network_driver,
                 )
             except KeyError as err:
                 self.job.logger.error(
@@ -255,11 +272,17 @@ class SyncDevicesNetworkAdapter(diffsync.Adapter):
                 self.job.logger.debug(f"loading device_type data for {ip_address}")
             onboarding_device_type = None
             try:
+                form_platform = self.job.ip_address_inventory[ip_address].get("platform")
+                manufacturer_name = (
+                    form_platform.manufacturer.name
+                    if form_platform and form_platform.manufacturer
+                    else self.device_data[ip_address]["manufacturer"]
+                )
                 onboarding_device_type = self.device_type(
                     adapter=self,
                     model=self.device_data[ip_address]["device_type"],
                     part_number=self.device_data[ip_address]["device_type"],
-                    manufacturer__name=self.device_data[ip_address]["manufacturer"],
+                    manufacturer__name=manufacturer_name,
                 )
             except KeyError as err:
                 self.job.logger.error(
@@ -309,6 +332,11 @@ class SyncDevicesNetworkAdapter(diffsync.Adapter):
                 onboarding_device = self.device(
                     adapter=self,
                     device_type__model=self.device_data[ip_address]["device_type"],
+                    device_type__manufacturer__name=(
+                        platform.manufacturer.name
+                        if platform and platform.manufacturer
+                        else self.device_data[ip_address]["manufacturer"]
+                    ),
                     location__name=location.name,
                     name=self.device_data[ip_address]["hostname"],
                     platform__name=(platform.name if platform else self.device_data[ip_address]["platform"]),

--- a/nautobot_device_onboarding/diffsync/models/sync_devices_models.py
+++ b/nautobot_device_onboarding/diffsync/models/sync_devices_models.py
@@ -25,6 +25,7 @@ class SyncDevicesDevice(DiffSyncModel):
     )
     _attributes = (
         "device_type__model",
+        "device_type__manufacturer__name",
         "mask_length",
         "primary_ip4__host",
         "primary_ip4__status__name",
@@ -41,6 +42,7 @@ class SyncDevicesDevice(DiffSyncModel):
     serial: str
 
     device_type__model: Optional[str] = None
+    device_type__manufacturer__name: Optional[str] = None
     mask_length: Optional[int] = None
     primary_ip4__host: Optional[str] = None
     primary_ip4__status__name: Optional[str] = None
@@ -90,7 +92,10 @@ class SyncDevicesDevice(DiffSyncModel):
                 status=job_form_attrs["device_status"],
                 tenant=job_form_attrs["device_tenant"],
                 role=job_form_attrs["device_role"],
-                device_type=DeviceType.objects.get(model=attrs["device_type__model"]),
+                device_type=DeviceType.objects.get(
+                    model=attrs["device_type__model"],
+                    manufacturer=platform.manufacturer,
+                ),
                 name=ids["name"],
                 platform=platform,
                 secrets_group=job_form_attrs["secrets_group"],
@@ -147,7 +152,10 @@ class SyncDevicesDevice(DiffSyncModel):
         device.location = job_form_attrs["location"]
         device.status = job_form_attrs["device_status"]
         device.role = job_form_attrs["device_role"]
-        device.device_type = DeviceType.objects.get(model=attrs["device_type__model"])
+        device.device_type = DeviceType.objects.get(
+            model=attrs["device_type__model"],
+            manufacturer=platform.manufacturer,
+        )
         device.platform = platform
         device.secrets_group = job_form_attrs["secrets_group"]
         device.serial = ids["serial"]
@@ -224,10 +232,17 @@ class SyncDevicesDevice(DiffSyncModel):
 
         if self.adapter.job.debug:
             self.adapter.job.logger.debug(f"Updating {device.name} with attrs: {attrs}")
-        if attrs.get("device_type__model"):
-            device.device_type = DeviceType.objects.get(model=attrs.get("device_type__model"))
-        if attrs.get("platform__name"):
-            device.platform = Platform.objects.get(name=attrs.get("platform__name"))
+
+        new_platform = Platform.objects.get(name=attrs["platform__name"]) if attrs.get("platform__name") else None
+
+        if attrs.get("device_type__model") or attrs.get("device_type__manufacturer__name"):
+            target_platform = new_platform or device.platform
+            device.device_type = DeviceType.objects.get(
+                model=attrs.get("device_type__model") or device.device_type.model,
+                manufacturer=target_platform.manufacturer if target_platform else None,
+            )
+        if new_platform:
+            device.platform = new_platform
         if attrs.get("role__name"):
             device.role = Role.objects.get(name=attrs.get("role__name"))
         if attrs.get("status__name"):

--- a/nautobot_device_onboarding/nornir_plays/processor.py
+++ b/nautobot_device_onboarding/nornir_plays/processor.py
@@ -7,6 +7,7 @@ from nornir.core.inventory import Host
 from nornir.core.task import MultiResult, Task
 from nornir_nautobot.plugins.processors import BaseLoggingProcessor
 
+from nautobot_device_onboarding.constants import NETWORK_DRIVER_TO_MANUFACTURER
 from nautobot_device_onboarding.nornir_plays.formatter import extract_show_data
 from nautobot_device_onboarding.nornir_plays.schemas import NETWORK_DATA_SCHEMA, NETWORK_DEVICES_SCHEMA
 from nautobot_device_onboarding.utils.helper import close_threaded_db_connections
@@ -26,7 +27,11 @@ class CommandGetterProcessor(BaseLoggingProcessor):
         if not self.data.get(host.name):
             self.data[host.name] = {
                 "platform": host.platform,
-                "manufacturer": host.platform.split("_")[0].title() if host.platform else "PLACEHOLDER",
+                "manufacturer": (
+                    NETWORK_DRIVER_TO_MANUFACTURER.get(host.platform, host.platform.split("_")[0].title())
+                    if host.platform
+                    else "PLACEHOLDER"
+                ),
                 "network_driver": host.platform,
             }
 

--- a/nautobot_device_onboarding/tests/test_processor.py
+++ b/nautobot_device_onboarding/tests/test_processor.py
@@ -1,0 +1,36 @@
+"""Tests for CommandGetterProcessor manufacturer/platform derivation."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from nautobot_device_onboarding.nornir_plays.processor import CommandGetterProcessor
+
+
+class TestManufacturerDerivation(unittest.TestCase):
+    """task_instance_started should produce the correct Nautobot Manufacturer display name."""
+
+    def _run(self, platform):
+        outputs = {}
+        processor = CommandGetterProcessor(logger=MagicMock(), command_outputs=outputs, job=MagicMock(debug=False))
+        host = MagicMock(platform=platform)
+        host.name = "10.0.0.1"
+        processor.task_instance_started(task=MagicMock(), host=host)
+        return outputs["10.0.0.1"]
+
+    def test_paloalto_panos_maps_to_palo_alto(self):
+        self.assertEqual(self._run("paloalto_panos")["manufacturer"], "Palo Alto")
+
+    def test_juniper_junos_legacy_mapping_preserved(self):
+        self.assertEqual(self._run("juniper_junos")["manufacturer"], "Juniper")
+
+    def test_cisco_ios_legacy_mapping_preserved(self):
+        self.assertEqual(self._run("cisco_ios")["manufacturer"], "Cisco")
+
+    def test_unknown_token_falls_back_to_split_title(self):
+        self.assertEqual(self._run("someNew_vendor")["manufacturer"], "Somenew")
+
+    def test_missing_platform_is_placeholder(self):
+        self.assertEqual(self._run(None)["manufacturer"], "PLACEHOLDER")
+
+    def test_platform_string_is_netmiko_token_unchanged(self):
+        self.assertEqual(self._run("paloalto_panos")["platform"], "paloalto_panos")

--- a/nautobot_device_onboarding/tests/test_sync_devices_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_devices_adapters.py
@@ -119,6 +119,57 @@ class SyncDevicesNetworkAdapterTestCase(TransactionTestCase):
         result = sync_devices_command_getter(job=self.job, log_level="INFO")
         self.assertEqual(result, {})
 
+    @patch("nautobot_device_onboarding.diffsync.adapters.sync_devices_adapters.sync_devices_command_getter")
+    def test_load_respects_form_supplied_platform_manufacturer(self, device_data):
+        """When the job form supplies a Platform, its Manufacturer.name wins over the processor-derived value."""
+        palo_mfr, _ = Manufacturer.objects.get_or_create(name="Palo Alto")
+        palo_platform, _ = Platform.objects.get_or_create(
+            name="Palo Alto PanOS",
+            defaults={"manufacturer": palo_mfr, "network_driver": "paloalto_panos"},
+        )
+        device_data.return_value = {
+            "10.1.1.50": {
+                "hostname": "palo-fw-1",
+                "serial": "SN-PALO-001",
+                "device_type": "PA-220",
+                "mgmt_interface": "management",
+                "manufacturer": "Paloalto",
+                "platform": "paloalto_panos",
+                "network_driver": "paloalto_panos",
+                "mask_length": 24,
+            },
+        }
+
+        self.job.debug = True
+        processed_ip_address_attrs = {
+            "location": self.testing_objects["location"],
+            "namespace": self.testing_objects["namespace"],
+            "port": 22,
+            "timeout": 30,
+            "update_devices_without_primary_ip": True,
+            "device_role": self.testing_objects["device_role"],
+            "device_status": self.testing_objects["status"],
+            "device_tenant": self.testing_objects["device_tenant_1"],
+            "interface_status": self.testing_objects["status"],
+            "ip_address_status": self.testing_objects["status"],
+            "secrets_group": self.testing_objects["secrets_group"],
+            "set_mgmt_only": False,
+            "platform": palo_platform,
+        }
+        self.job.ip_address_inventory = {"10.1.1.50": processed_ip_address_attrs}
+
+        self.sync_devices_adapter.load()
+
+        self.assertTrue(self.sync_devices_adapter.get("manufacturer", "Palo Alto"))
+        with self.assertRaises(ObjectNotFound):
+            self.sync_devices_adapter.get("manufacturer", "Paloalto")
+
+        diff_platform = self.sync_devices_adapter.get("platform", "Palo Alto PanOS")
+        self.assertEqual(diff_platform.manufacturer__name, "Palo Alto")
+
+        diff_device_type = self.sync_devices_adapter.get("device_type", "PA-220__Palo Alto")
+        self.assertEqual(diff_device_type.manufacturer__name, "Palo Alto")
+
 
 class SyncDevicesNautobotAdapterTestCase(TransactionTestCase):
     """Test SyncDevicesNautobotAdapter class."""

--- a/nautobot_device_onboarding/tests/test_sync_devices_models.py
+++ b/nautobot_device_onboarding/tests/test_sync_devices_models.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from nautobot.apps.testing import TransactionTestCase, create_job_result_and_run_job
-from nautobot.dcim.models import Device, Interface
+from nautobot.dcim.models import Device, DeviceType, Interface, Manufacturer, Platform
 from nautobot.extras.choices import JobResultStatusChoices
 
 from nautobot_device_onboarding.tests import utils
@@ -166,3 +166,71 @@ class SyncDevicesDeviceTestCase(TransactionTestCase):
 
         old_mgmt_interface = Interface.objects.get(device=device, name="GigabitEthernet1")
         self.assertNotIn("192.1.1.10", list(old_mgmt_interface.ip_addresses.all().values_list("host", flat=True)))
+
+    @patch("nautobot_device_onboarding.diffsync.adapters.sync_devices_adapters.sync_devices_command_getter")
+    def test_device_create__form_platform_scopes_device_type_lookup__success(self, device_data):
+        """During create, the DeviceType lookup is scoped to the form Platform's Manufacturer.
+
+        Two DeviceTypes share the same model name under different Manufacturers; the form
+        Platform's Manufacturer is what disambiguates which one the device gets.
+        Test data already creates CSR1000V17 so re-using that model rather than adding to the test data.
+        """
+        palo_mfr, _ = Manufacturer.objects.get_or_create(name="Palo Alto")
+        palo_platform, _ = Platform.objects.get_or_create(
+            name="Palo Alto PanOS",
+            defaults={"manufacturer": palo_mfr, "network_driver": "paloalto_panos"},
+        )
+        palo_devicetype, _ = DeviceType.objects.get_or_create(
+            model="CSR1000V17",
+            manufacturer=palo_mfr,
+            defaults={"part_number": "CSR1000V17"},
+        )
+        self.assertEqual(DeviceType.objects.filter(model="CSR1000V17").count(), 2)
+
+        device_data.return_value = {
+            "192.1.1.50": {
+                "hostname": "palo-fw-1",
+                "serial": "SN-PALO-001",
+                "device_type": "CSR1000V17",
+                "mgmt_interface": "management",
+                "manufacturer": "Palo Alto",
+                "platform": "paloalto_panos",
+                "network_driver": "paloalto_panos",
+                "mask_length": 24,
+            },
+        }
+
+        job_form_inputs = {
+            "debug": True,
+            "connectivity_test": False,
+            "dryrun": False,
+            "csv_file": None,
+            "location": self.testing_objects["location"].pk,
+            "namespace": self.testing_objects["namespace"].pk,
+            "ip_addresses": "192.1.1.50",
+            "port": 22,
+            "timeout": 30,
+            "set_mgmt_only": True,
+            "update_devices_without_primary_ip": True,
+            "device_role": self.testing_objects["device_role"].pk,
+            "device_status": self.testing_objects["status"].pk,
+            "device_tenant": self.testing_objects["device_tenant_1"].pk,
+            "interface_status": self.testing_objects["status"].pk,
+            "ip_address_status": self.testing_objects["status"].pk,
+            "secrets_group": self.testing_objects["secrets_group"].pk,
+            "platform": palo_platform.pk,
+            "memory_profiling": False,
+            "fail_job_on_task_failure": False,
+        }
+        job_result = create_job_result_and_run_job(
+            module="nautobot_device_onboarding.jobs", name="SSOTSyncDevices", **job_form_inputs
+        )
+
+        self.assertEqual(
+            job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
+        )
+        device = Device.objects.get(serial="SN-PALO-001")
+        self.assertEqual(device.device_type.pk, palo_devicetype.pk)
+        self.assertEqual(device.device_type.manufacturer.name, "Palo Alto")


### PR DESCRIPTION
# Closes: #555 

## What's Changed
Fixed erroneous Manufacturer (Paloalto) created, and a Duplicate DeviceType `(MultipleObjectsReturned)`exception when the same model exists under multiple manufacturers. Also when setting a Platform manually, it did not override the built-in Platform/etc selection, so unable to resolve the issue manually.

- Created a new `NETWORK_DRIVER_TO_MANUFACTURER` map to facilitate Manufacturer naming
  - Allows the existing technique for all drivers EXCEPT Palo, allowing for easy future updates as needed.
- Update to ensure the various `DeviceType` lookups filter on Manufacturer name as well, not just model name (to avoid `MultipleObjectsReturned` exception and ensure DeviceType updates appropriately)
- Update to ensure that if a Platform is sent in, (via CSV or web form), and the device already exists in Nautobot, it will be updated appropriately.
- Tests created for the Manufacturer names themselves
- Test created to ensure that the form supplied Platform is used if found.
