### PR TITLE
fix bug with get_vlan_data jinja filter

### DIFF
--- a/changes/557.fixed
+++ b/changes/557.fixed
@@ -1,0 +1,1 @@
+Fixed `get_vlan_data` Jinja filter raising an error when trunking VLANs were reported as `NONE` by the device, so trunk interfaces with no tagged VLANs are now handled correctly.

--- a/nautobot_device_onboarding/jinja_filters.py
+++ b/nautobot_device_onboarding/jinja_filters.py
@@ -167,7 +167,7 @@ def get_vlan_data(item, vlan_mapping, tag_type):  # pylint: disable=too-many-ret
                 trunk_vlans = [current_item["trunking_vlans"]]
             else:
                 trunk_vlans = current_item["trunking_vlans"]
-            if "none" in trunk_vlans:
+            if any(isinstance(v, str) and v.lower() == "none" for v in trunk_vlans):
                 return []
             return [
                 {"id": str(vid), "name": vlan_mapping.get(str(vid), f"VLAN{str(vid).zfill(4)}")}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #557 

## What's Changed
Devices configured with `Trunking VLANs Enabled: NONE` now onboard interfaces correctly
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
