### PR TITLE
Add Palo Alto to matrix for sync network jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,29 +33,29 @@ Regardless, the Onboarding App greatly simplifies the onboarding process by allo
 
 ### Support Matrix (Sync Data From Network)
 
-|     Interfaces          | Cisco IOS          | Cisco XE           | Cisco NXOS         | Cisco XR | Cisco WLC          | Juniper Junos      | Arista EOS         | F5  | Aruba AOSCX | Aruba OS | Brocade/Ruckus Fastiron | HP Procurve |
-| ----------------------- | :----------------: |  :--------------:  |  :--------------:  | :-: | :--------------:  |  :--------------:  |  :--------------:  | :-: | :--------------: | :--------------: | :--------------: | :--------------: |
-| Name           | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| IP Address     | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Type           | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| MTU            | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Description    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Mac Address    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Link Status    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| 802.1Q mode    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Lag Member     | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Vrf Membership | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Software Version | ✅ | ✅ | ✅  | 🧪 | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
+|     Interfaces          | Cisco IOS          | Cisco XE           | Cisco NXOS         | Cisco XR | Cisco WLC          | Juniper Junos      | Arista EOS         | F5  | Palo Alto Panos | Aruba AOSCX | Aruba OS | Brocade/Ruckus Fastiron | HP Procurve |
+| ----------------------- | :----------------: |  :--------------:  |  :--------------:  | :-: | :--------------:  |  :--------------:  |  :--------------:  | :-: | :-: | :--------------: | :--------------: | :--------------: | :--------------: |
+| Name           | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| IP Address     | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Type           | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| MTU            | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Description    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Mac Address    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Link Status    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| 802.1Q mode    | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Lag Member     | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Vrf Membership | ✅ | ✅ | ✅ | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Software Version | ✅ | ✅ | ✅  | 🧪 | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
 
-|     VLANS          | Cisco IOS          | Cisco XE           | Cisco XR           | Cisco NXOS         | Cisco WLC          | Juniper Junos      | Arista EOS         | F5  | Aruba AOSCX | Aruba OS | Brocade/Ruckus Fastiron | HP Procurve |
-| ----------------------- | :----------------: |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  | :-: | :--------------: | :--------------: | :--------------: | :--------------: |
-| Untagged VLANs       | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-| Tagged VLANs        | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
+|     VLANS          | Cisco IOS          | Cisco XE           | Cisco XR           | Cisco NXOS         | Cisco WLC          | Juniper Junos      | Arista EOS         | F5  | Palo Alto Panos | Aruba AOSCX | Aruba OS | Brocade/Ruckus Fastiron | HP Procurve |
+| ----------------------- | :----------------: |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  | :-: | :-: | :--------------: | :--------------: | :--------------: | :--------------: |
+| Untagged VLANs       | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+| Tagged VLANs        | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
 
-|     Cabling          | Cisco IOS          | Cisco XE           | Cisco XR           | Cisco NXOS         | Cisco WLC          | Juniper Junos      | Arista EOS         | F5  | Aruba AOSCX | Aruba OS | Brocade/Ruckus Fastiron | HP Procurve |
-| ----------------------- | :----------------: |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  | :-: | :--------------: | :--------------: | :--------------: | :--------------: |
-|  Terminations A      | 🧪 | 🧪 | ❌ | 🧪 | ❌ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
-|  Terminations B      | 🧪 | 🧪 | ❌ | 🧪 | ❌ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 | 🧪 |
+|     Cabling          | Cisco IOS          | Cisco XE           | Cisco XR           | Cisco NXOS         | Cisco WLC          | Juniper Junos      | Arista EOS         | F5  | Palo Alto Panos | Aruba AOSCX | Aruba OS | Brocade/Ruckus Fastiron | HP Procurve |
+| ----------------------- | :----------------: |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  |  :--------------:  | :-: | :-: | :--------------: | :--------------: | :--------------: | :--------------: |
+|  Terminations A      | 🧪 | 🧪 | ❌ | 🧪 | ❌ | 🧪 | ❌ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
+|  Terminations B      | 🧪 | 🧪 | ❌ | 🧪 | ❌ | 🧪 | ❌ | 🧪 | ❌ | 🧪 | 🧪 | 🧪 | 🧪 |
 
 | Legend |
 | :---- |

--- a/changes/559.documentation
+++ b/changes/559.documentation
@@ -1,0 +1,1 @@
+Add Palo Alto to support matrix for sync network data jobs.


### PR DESCRIPTION
Palo Alto has support for the `sync devices` Job, but not the `network data` job. The support matrix lists Palo Alto for the `sync devices` Job, but is missing from the list of vendors in `network data` sections, this PR adds Palo Alto to the list, to more clearly show the current support status.
