### PR TITLE
Fix silently dropped per-host failure messages in sync jobs

### DIFF
--- a/changes/561.fixed
+++ b/changes/561.fixed
@@ -1,1 +1,1 @@
-Fixed netmiko_send_commands error messages from silently being dropped.
+Fix silently dropped per-host failure messages in sync jobs.

--- a/changes/561.fixed
+++ b/changes/561.fixed
@@ -1,0 +1,1 @@
+Fixed netmiko_send_commands error messages from silently being dropped.

--- a/nautobot_device_onboarding/tests/test_command_getter.py
+++ b/nautobot_device_onboarding/tests/test_command_getter.py
@@ -8,8 +8,15 @@ import yaml
 from nautobot.apps.testing import TransactionTestCase
 from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
 from nautobot.extras.models import Secret, SecretsGroup, SecretsGroupAssociation
+from netmiko.exceptions import NetmikoAuthenticationException, NetmikoTimeoutException
+from nornir.core.exceptions import NornirSubTaskError
+from nornir.core.task import Result
 
-from nautobot_device_onboarding.nornir_plays.command_getter import _get_commands_to_run, _parse_credentials
+from nautobot_device_onboarding.nornir_plays.command_getter import (
+    _get_commands_to_run,
+    _parse_credentials,
+    netmiko_send_commands,
+)
 from nautobot_device_onboarding.nornir_plays.logger import NornirLogger
 
 MOCK_DIR = os.path.join("nautobot_device_onboarding", "tests", "mock")
@@ -290,3 +297,113 @@ class TestSSHCredParsing(TransactionTestCase):
             "napalm_admin",
             "napalamP$$w0rd",
         )
+
+
+class TestNetmikoSendCommandsEarlyReturns(unittest.TestCase):
+    """Pin the failure messages emitted by `netmiko_send_commands` early-return paths.
+
+    These were silently dropped before `close_threaded_db_connections` was fixed to
+    return the wrapped function's value; without that fix every assertion below sees
+    `None` instead of a `Result`.
+    """
+
+    def test_no_platform_returns_failed_result(self):
+        task = MagicMock()
+        task.host.name = "test-host"
+        task.host.platform = None
+
+        result = netmiko_send_commands(task, {}, "sync_devices", MagicMock(), MagicMock())
+
+        self.assertIsInstance(result, Result)
+        self.assertTrue(result.failed)
+        self.assertEqual(result.result, "test-host has no platform set.")
+
+    def test_unsupported_platform_returns_failed_result(self):
+        task = MagicMock()
+        task.host.name = "test-host"
+        task.host.platform = "made_up_platform"
+
+        result = netmiko_send_commands(task, {}, "sync_devices", MagicMock(), MagicMock())
+
+        self.assertIsInstance(result, Result)
+        self.assertTrue(result.failed)
+        self.assertEqual(result.result, "test-host has a unsupported platform set.")
+
+    def test_missing_yaml_definitions_returns_failed_result(self):
+        # paloalto_panos ships with `sync_devices` but no `sync_network_data` definitions,
+        # so requesting the latter should hit the missing-definitions branch.
+        task = MagicMock()
+        task.host.name = "test-host"
+        task.host.platform = "paloalto_panos"
+        yaml_data = {"paloalto_panos": {"sync_devices": {"hostname": {"commands": []}}}}
+
+        result = netmiko_send_commands(task, yaml_data, "sync_network_data", MagicMock(), MagicMock())
+
+        self.assertIsInstance(result, Result)
+        self.assertTrue(result.failed)
+        self.assertEqual(result.result, "test-host has missing definitions in command_mapper YAML file.")
+
+    @patch("nautobot_device_onboarding.nornir_plays.command_getter.tcp_ping", MagicMock(return_value=False))
+    def test_tcp_ping_failure_returns_failed_result(self):
+        task = MagicMock()
+        task.host.name = "test-host"
+        task.host.hostname = "198.51.100.1"
+        task.host.port = 22
+        task.host.platform = "cisco_ios"
+        nautobot_job = MagicMock()
+        nautobot_job.connectivity_test = True
+        yaml_data = {"cisco_ios": {"sync_devices": {"command": "show version", "parser": "raw"}}}
+
+        result = netmiko_send_commands(task, yaml_data, "sync_devices", MagicMock(), nautobot_job)
+
+        self.assertIsInstance(result, Result)
+        self.assertTrue(result.failed)
+        self.assertEqual(result.result, "test-host failed connectivity check via tcp_ping.")
+
+    @patch(
+        "nautobot_device_onboarding.nornir_plays.command_getter._get_commands_to_run",
+        MagicMock(return_value=[{"command": "show version", "parser": "raw"}]),
+    )
+    def test_netmiko_authentication_exception_returns_failed_result(self):
+        task = MagicMock()
+        task.host.name = "test-host"
+        task.host.platform = "cisco_ios"
+        task.host.data = {}
+        sub_result = MagicMock()
+        sub_result.exception = NetmikoAuthenticationException()
+        task.results = [sub_result]
+        task.run.side_effect = NornirSubTaskError(task=task, result=MagicMock())
+        nautobot_job = MagicMock()
+        nautobot_job.connectivity_test = False
+        nautobot_job.fail_job_on_task_failure = False
+        yaml_data = {"cisco_ios": {"sync_devices": {"command": "show version", "parser": "raw"}}}
+
+        result = netmiko_send_commands(task, yaml_data, "sync_devices", MagicMock(), nautobot_job)
+
+        self.assertIsInstance(result, Result)
+        self.assertTrue(result.failed)
+        self.assertEqual(result.result, "test-host failed authentication.")
+
+    @patch(
+        "nautobot_device_onboarding.nornir_plays.command_getter._get_commands_to_run",
+        MagicMock(return_value=[{"command": "show version", "parser": "raw"}]),
+    )
+    def test_netmiko_timeout_exception_returns_failed_result(self):
+        task = MagicMock()
+        task.host.name = "test-host"
+        task.host.platform = "cisco_ios"
+        task.host.data = {}
+        sub_result = MagicMock()
+        sub_result.exception = NetmikoTimeoutException()
+        task.results = [sub_result]
+        task.run.side_effect = NornirSubTaskError(task=task, result=MagicMock())
+        nautobot_job = MagicMock()
+        nautobot_job.connectivity_test = False
+        nautobot_job.fail_job_on_task_failure = False
+        yaml_data = {"cisco_ios": {"sync_devices": {"command": "show version", "parser": "raw"}}}
+
+        result = netmiko_send_commands(task, yaml_data, "sync_devices", MagicMock(), nautobot_job)
+
+        self.assertIsInstance(result, Result)
+        self.assertTrue(result.failed)
+        self.assertEqual(result.result, "test-host SSH Timeout Occured.")

--- a/nautobot_device_onboarding/utils/helper.py
+++ b/nautobot_device_onboarding/utils/helper.py
@@ -128,7 +128,7 @@ def close_threaded_db_connections(func):
 
     def inner(*args, **kwargs):
         try:
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         finally:
             connections.close_all()
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #561 

## What's Changed

The [close_threaded_db_connections](https://github.com/nautobot/nautobot-app-device-onboarding/blob/fca5832de2bb452667a0ee69b61e082bc66d06d8/nautobot_device_onboarding/utils/helper.py#L131) decorator was discarding its wrapped function's return value, so these logs from `netmiko_send_commands` were silently swallowed and never appear in the Job Result log entries (and eventually hits an exception). 

Simply added `return` to the decorator's inner call so the value passes through. Added (possibly unnecessary?) tests ensuring these logs appear in the future.

Copying the table from [the Issue](https://github.com/nautobot/nautobot-app-device-onboarding/issues/561) which lists out the log messages previously getting dropped:
| # | Location | Message |
|---|----------|---------|
| 1 | [command_getter.py:125](https://github.com/nautobot/nautobot-app-device-onboarding/blob/develop/nautobot_device_onboarding/nornir_plays/command_getter.py#L125) | `f"{task.host.name} has no platform set."` |
| 2 | [command_getter.py:127](https://github.com/nautobot/nautobot-app-device-onboarding/blob/develop/nautobot_device_onboarding/nornir_plays/command_getter.py#L127) | `f"{task.host.name} has a unsupported platform set."` |
| 3 | [command_getter.py:130](https://github.com/nautobot/nautobot-app-device-onboarding/blob/develop/nautobot_device_onboarding/nornir_plays/command_getter.py#L130) | `f"{task.host.name} has missing definitions in command_mapper YAML file."` |
| 4 | [command_getter.py:135](https://github.com/nautobot/nautobot-app-device-onboarding/blob/develop/nautobot_device_onboarding/nornir_plays/command_getter.py#L135) | `f"{task.host.name} failed connectivity check via tcp_ping."` |
| 5 | [command_getter.py:266](https://github.com/nautobot/nautobot-app-device-onboarding/blob/develop/nautobot_device_onboarding/nornir_plays/command_getter.py#L266) | `f"{task.host.name} failed authentication."` |
| 6 | [command_getter.py:268](https://github.com/nautobot/nautobot-app-device-onboarding/blob/develop/nautobot_device_onboarding/nornir_plays/command_getter.py#L268) | `f"{task.host.name} SSH Timeout Occured."` |

