### PR TITLE
Fix IPAddressToInterface namespace lookup

### DIFF
--- a/changes/563.fixed
+++ b/changes/563.fixed
@@ -1,0 +1,1 @@
+Fixed Sync Network Data From Network failing with `Found multiple instances for ip_address` when the same IP host existed in multiple Nautobot namespaces.

--- a/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
+++ b/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
@@ -152,7 +152,6 @@ class SyncNetworkDataIPAddress(DiffSyncModel):
         diffsync_utils.get_or_create_ip_address(
             host=ids["host"],
             mask_length=attrs["mask_length"],
-            # namespace=adapter.job.namespace,
             namespace=Namespace.objects.get(name=ids["namespace"]),
             default_ip_status=adapter.job.ip_address_status,
             default_prefix_status=adapter.job.default_prefix_status,

--- a/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
+++ b/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
@@ -136,11 +136,11 @@ class SyncNetworkDataIPAddress(DiffSyncModel):
     """Shared data model representing an IPAddress."""
 
     _modelname = "ip_address"
-    _identifiers = ("host",)
+    _identifiers = ("host", "namespace")
     _attributes = ("type", "ip_version", "mask_length", "status__name")
 
     host: str
-
+    namespace: str
     mask_length: int
     type: str
     ip_version: int
@@ -152,7 +152,8 @@ class SyncNetworkDataIPAddress(DiffSyncModel):
         diffsync_utils.get_or_create_ip_address(
             host=ids["host"],
             mask_length=attrs["mask_length"],
-            namespace=adapter.job.namespace,
+            # namespace=adapter.job.namespace,
+            namespace=Namespace.objects.get(name=ids["namespace"]),
             default_ip_status=adapter.job.ip_address_status,
             default_prefix_status=adapter.job.default_prefix_status,
             job=adapter.job,
@@ -162,15 +163,21 @@ class SyncNetworkDataIPAddress(DiffSyncModel):
     def update(self, attrs):
         """Update an existing IPAddress object."""
         try:
-            ip_address = IPAddress.objects.get(host=self.host, parent__namespace=self.adapter.job.namespace)
+            ip_address = IPAddress.objects.get(
+                host=self.host,
+                parent__namespace__name=self.namespace,
+            )
         except ObjectDoesNotExist as err:
             self.adapter.job.logger.error(f"{self} failed to update, {err}")
+            return super().update(attrs)
+
         if attrs.get("mask_length"):
             ip_address.mask_length = attrs["mask_length"]
         if attrs.get("status__name"):
             ip_address.status = Status.objects.get(name=attrs["status__name"])
         if attrs.get("ip_version"):
             ip_address.ip_version = attrs["ip_version"]
+
         try:
             ip_address.validated_save()
         except ValidationError as err:
@@ -184,11 +191,17 @@ class SyncNetworkDataIPAddressToInterface(FilteredNautobotModel):
 
     _modelname = "ipaddress_to_interface"
     _model = IPAddressToInterface
-    _identifiers = ("interface__device__name", "interface__name", "ip_address__host")
+    _identifiers = (
+        "interface__device__name",
+        "interface__name",
+        "ip_address__host",
+        "ip_address__parent__namespace__name",
+    )
 
     interface__device__name: str
     interface__name: str
     ip_address__host: str
+    ip_address__parent__namespace__name: str
 
     @classmethod
     def _get_queryset(cls, adapter: "Adapter"):

--- a/nautobot_device_onboarding/tests/test_ip_namespace_bug.py
+++ b/nautobot_device_onboarding/tests/test_ip_namespace_bug.py
@@ -1,0 +1,133 @@
+"""Regression test for IPAddressToInterface namespace lookup bug.
+
+Demonstrates that SyncNetworkDataIPAddressToInterface fails during sync when
+the same IP host exists in multiple Nautobot namespaces. The nautobot-ssot contrib
+NautobotModel.create() resolves the ip_address FK using only the fields present
+in _identifiers. Without ip_address__parent__namespace__name in _identifiers, it
+queries IPAddress.objects.get(host=...) which returns MultipleObjectsReturned.
+
+Error observed in production:
+    Found multiple instances for ip_address with: {'host': '192.168.220.230'}
+    No object resulted from sync, will not process child objects.
+
+To run:
+    invoke unittest --label nautobot_device_onboarding.tests.test_ip_namespace_bug
+"""
+
+from nautobot.apps.testing import TransactionTestCase
+from nautobot.dcim.models import Device
+from nautobot.extras.models import JobResult
+from nautobot.ipam.choices import IPAddressTypeChoices, PrefixTypeChoices
+from nautobot.ipam.models import IPAddress, Namespace, Prefix
+
+from nautobot_device_onboarding.diffsync.adapters.sync_network_data_adapters import (
+    SyncNetworkDataNautobotAdapter,
+)
+from nautobot_device_onboarding.jobs import SSOTSyncNetworkData
+from nautobot_device_onboarding.tests import utils
+from nautobot_device_onboarding.tests.fixtures import sync_network_data_fixture
+
+
+class IPAddressToInterfaceNamespaceBugTestCase(TransactionTestCase):
+    """Prove that duplicate IPs across namespaces break IPAddressToInterface sync.
+
+    When two IPAddress records share the same host value in different Nautobot
+    namespaces, the nautobot-ssot contrib FK resolution fails because it queries
+    IPAddress using only {'host': ...} — which is not unique.
+
+    The fix adds ip_address__parent__namespace__name to the model _identifiers
+    so the FK resolution query becomes:
+        IPAddress.objects.get(host=..., parent__namespace__name=...)
+    """
+
+    databases = ("default", "job_logs")
+
+    def setUp(self):
+        """Set up test data: standard objects plus a second namespace with duplicate IPs."""
+        self.testing_objects = utils.sync_network_data_ensure_required_nautobot_objects()
+
+        # Create a second namespace with the same IP hosts as the Global namespace.
+        # This is the condition that triggers the bug.
+        self.second_namespace, _ = Namespace.objects.get_or_create(name="Secondary")
+        second_prefix, _ = Prefix.objects.get_or_create(
+            prefix="10.1.1.0/24",
+            namespace=self.second_namespace,
+            type=PrefixTypeChoices.TYPE_NETWORK,
+            status=self.testing_objects["status"],
+        )
+        # Create duplicate IPs in the second namespace — same hosts as in Global
+        self.dup_ip_1, _ = IPAddress.objects.get_or_create(
+            host="10.1.1.10",
+            mask_length=24,
+            type=IPAddressTypeChoices.TYPE_HOST,
+            status=self.testing_objects["status"],
+            parent=second_prefix,
+        )
+        self.dup_ip_2, _ = IPAddress.objects.get_or_create(
+            host="10.1.1.11",
+            mask_length=24,
+            type=IPAddressTypeChoices.TYPE_HOST,
+            status=self.testing_objects["status"],
+            parent=second_prefix,
+        )
+
+        # Verify duplicate IPs exist
+        self.assertGreater(
+            IPAddress.objects.filter(host="10.1.1.10").count(),
+            1,
+            "Test setup error: expected duplicate IP 10.1.1.10 across namespaces",
+        )
+
+        # Set up the job and adapters
+        self.job = SSOTSyncNetworkData()
+        self.job.job_result = JobResult.objects.create(
+            name=self.job.class_path, user=None, task_name="fake task", worker="default"
+        )
+        self.job.command_getter_result = sync_network_data_fixture.sync_network_mock_data_valid
+        self.job.interface_status = self.testing_objects["status"]
+        self.job.ip_address_status = self.testing_objects["status"]
+        self.job.location = self.testing_objects["location"]
+        self.job.namespace = self.testing_objects["namespace"]  # Global
+        self.job.sync_vlans = True
+        self.job.sync_vrfs = True
+        self.job.sync_vrf_to_prefix = False
+        self.job.sync_cables = False
+        self.job.sync_software_version = True
+        self.job.default_prefix_status = self.testing_objects["status"]
+        self.job.debug = True
+        self.job.devices_to_load = Device.objects.filter(name__in=["demo-cisco-1", "demo-cisco-2", "demo-cisco-4"])
+
+    def test_nautobot_adapter_loads_ipaddress_to_interface_with_duplicate_ips(self):
+        """Loading IPAddressToInterface from Nautobot should succeed with duplicate IPs across namespaces.
+
+        On unpatched code (without ip_address__parent__namespace__name in _identifiers),
+        the NautobotAdapter._load_objects call for ipaddress_to_interface fails because
+        nautobot-ssot's contrib code resolves FK fields using the identifier field names.
+
+        With only ip_address__host in _identifiers, the FK resolution dict is
+        {'host': '10.1.1.10'} and IPAddress.objects.get(**dict) raises
+        MultipleObjectsReturned, producing the error:
+            "Found multiple instances for ip_address with: {'host': '10.1.1.10'}"
+
+        With the fix (ip_address__parent__namespace__name added to _identifiers),
+        the resolution dict becomes {'host': '10.1.1.10', 'parent__namespace__name': 'Global'}
+        which uniquely identifies the correct IPAddress.
+        """
+        adapter = SyncNetworkDataNautobotAdapter(job=self.job, sync=None)
+
+        # This calls NautobotAdapter._load_objects for each top_level model,
+        # including ipaddress_to_interface. Without the namespace fix, the
+        # ipaddress_to_interface load will fail.
+        adapter.load()
+
+        # Verify ipaddress_to_interface objects were loaded successfully
+        loaded = adapter.get_all("ipaddress_to_interface")
+        self.assertGreater(len(loaded), 0, "Expected at least one IPAddressToInterface loaded")
+
+        # Verify the loaded objects include the namespace field
+        for obj in loaded:
+            self.assertEqual(
+                obj.ip_address__parent__namespace__name,
+                "Global",
+                "IPAddressToInterface should reference the Global namespace",
+            )

--- a/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
@@ -119,9 +119,10 @@ class SyncNetworkDataNetworkAdapterTestCase(TransactionTestCase):
                 if interface_data["ip_addresses"]:
                     for ip_address in interface_data["ip_addresses"]:
                         if ip_address["ip_address"]:
-                            unique_id = ip_address["ip_address"]
+                            unique_id = f"{ip_address['ip_address']}__{self.job.namespace.name}"
                             diffsync_obj = self.sync_network_data_adapter.get("ip_address", unique_id)
                             self.assertEqual(ip_address["ip_address"], diffsync_obj.host)
+                            self.assertEqual(self.job.namespace.name, diffsync_obj.namespace)
                             self.assertEqual(4, diffsync_obj.ip_version)
                             self.assertEqual(int(ip_address["prefix_length"]), diffsync_obj.mask_length)
                             self.assertEqual(self.job.ip_address_status.name, diffsync_obj.status__name)
@@ -168,11 +169,13 @@ class SyncNetworkDataNetworkAdapterTestCase(TransactionTestCase):
             for interface_name, interface_data in device_data["interfaces"].items():
                 for ip_address in interface_data["ip_addresses"]:
                     if ip_address["ip_address"]:
-                        unique_id = f"{hostname}__{interface_name}__{ip_address['ip_address']}"
+                        #unique_id = f"{hostname}__{interface_name}__{ip_address['ip_address']}"
+                        unique_id = f"{hostname}__{interface_name}__{ip_address['ip_address']}__{self.job.namespace.name}"
                         diffsync_obj = self.sync_network_data_adapter.get("ipaddress_to_interface", unique_id)
                         self.assertEqual(hostname, diffsync_obj.interface__device__name)
                         self.assertEqual(interface_name, diffsync_obj.interface__name)
                         self.assertEqual(ip_address["ip_address"], diffsync_obj.ip_address__host)
+                        self.assertEqual(self.job.namespace.name, diffsync_obj.ip_address__parent__namespace__name)
 
     def test_load_tagged_vlans_to_interface(self):
         """Test loading tagged vlan interface assignments into the Diffsync store."""
@@ -319,12 +322,14 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
             host__in=ip_address_hosts,
             parent__namespace__name=self.job.namespace.name,
         ):
-            unique_id = f"{ip_address.host}"
+            #unique_id = f"{ip_address.host}"
+            unique_id = f"{ip_address.host}__{ip_address.parent.namespace.name}"
             diffsync_obj = self.sync_network_data_adapter.get("ip_address", unique_id)
             self.assertEqual(ip_address.host, diffsync_obj.host)
             self.assertEqual(ip_address.ip_version, diffsync_obj.ip_version)
             self.assertEqual(ip_address.mask_length, diffsync_obj.mask_length)
             self.assertEqual(self.job.ip_address_status.name, diffsync_obj.status__name)
+            self.assertEqual(ip_address.parent.namespace.name, diffsync_obj.namespace)
 
     def test_load_vlans(self):
         """Test loading Nautobot vlan data into the diffsync store."""

--- a/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
@@ -169,8 +169,10 @@ class SyncNetworkDataNetworkAdapterTestCase(TransactionTestCase):
             for interface_name, interface_data in device_data["interfaces"].items():
                 for ip_address in interface_data["ip_addresses"]:
                     if ip_address["ip_address"]:
-                        #unique_id = f"{hostname}__{interface_name}__{ip_address['ip_address']}"
-                        unique_id = f"{hostname}__{interface_name}__{ip_address['ip_address']}__{self.job.namespace.name}"
+                        # unique_id = f"{hostname}__{interface_name}__{ip_address['ip_address']}"
+                        unique_id = (
+                            f"{hostname}__{interface_name}__{ip_address['ip_address']}__{self.job.namespace.name}"
+                        )
                         diffsync_obj = self.sync_network_data_adapter.get("ipaddress_to_interface", unique_id)
                         self.assertEqual(hostname, diffsync_obj.interface__device__name)
                         self.assertEqual(interface_name, diffsync_obj.interface__name)
@@ -322,7 +324,7 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
             host__in=ip_address_hosts,
             parent__namespace__name=self.job.namespace.name,
         ):
-            #unique_id = f"{ip_address.host}"
+            # unique_id = f"{ip_address.host}"
             unique_id = f"{ip_address.host}__{ip_address.parent.namespace.name}"
             diffsync_obj = self.sync_network_data_adapter.get("ip_address", unique_id)
             self.assertEqual(ip_address.host, diffsync_obj.host)

--- a/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
@@ -169,7 +169,6 @@ class SyncNetworkDataNetworkAdapterTestCase(TransactionTestCase):
             for interface_name, interface_data in device_data["interfaces"].items():
                 for ip_address in interface_data["ip_addresses"]:
                     if ip_address["ip_address"]:
-                        # unique_id = f"{hostname}__{interface_name}__{ip_address['ip_address']}"
                         unique_id = (
                             f"{hostname}__{interface_name}__{ip_address['ip_address']}__{self.job.namespace.name}"
                         )
@@ -324,7 +323,6 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
             host__in=ip_address_hosts,
             parent__namespace__name=self.job.namespace.name,
         ):
-            # unique_id = f"{ip_address.host}"
             unique_id = f"{ip_address.host}__{ip_address.parent.namespace.name}"
             diffsync_obj = self.sync_network_data_adapter.get("ip_address", unique_id)
             self.assertEqual(ip_address.host, diffsync_obj.host)


### PR DESCRIPTION
# Closes: #563

## What's Changed

- Adds `ip_address__parent__namespace__name` to `SyncNetworkDataIPAddressToInterface._identifiers` so the `nautobot-ssot` contrib FK resolution finds the correct `IPAddress` when the same host value exists in multiple Nautobot namespaces.
- Adds `namespace` to `SyncNetworkDataIPAddress._identifiers` for symmetry; updates both adapters and the existing adapter tests to reflect the new identifier shape.
- Adds a defensive early-return in `SyncNetworkDataIPAddress.update()` when the IP can't be located by host + namespace (was previously a hard crash).
- Adds a dedicated regression test (`tests/test_ip_namespace_bug.py`) that reproduces the production-observed `Found multiple instances for ip_address` failure and would have caught the bug on `develop`.

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design