### PR TITLE
Fix VRF lookup for VLAN SVI interfaces on Cisco IOS-XE

### DIFF
--- a/changes/565.fixed
+++ b/changes/565.fixed
@@ -1,0 +1,1 @@
+Fixed VRF assignment lookup for VLAN SVI interfaces on Cisco IOS-XE devices in the Sync Network Data From Network job.

--- a/nautobot_device_onboarding/command_mappers/cisco_xe.yml
+++ b/nautobot_device_onboarding/command_mappers/cisco_xe.yml
@@ -104,7 +104,7 @@ sync_network_data:
     commands:
       - command: "show ip vrf interfaces"
         parser: "textfsm"
-        jpath: "[?interface=='{{ current_key | abbreviated_interface_name(addl_reverse_map={'VirtualPortGroup': 'Vi'}) }}'].{name:vrf}"
+        jpath: "[?interface=='{{ current_key | abbreviated_interface_name(addl_name_map={'Vlan': 'VLAN'}, addl_reverse_map={'VirtualPortGroup': 'Vi'}) }}'].{name:vrf}"
         post_processor: "{% if obj | length > 0 %}{{ obj[0] | key_exist_or_default('name') | tojson }}{% else %}{{ obj }}{% endif %}"
         iterable_type: "dict"
   interfaces__tagged_vlans:


### PR DESCRIPTION
# Closes: #565

## What's Changed

- Adds `addl_name_map={'Vlan': 'VLAN'}` to the `abbreviated_interface_name` filter call in the `interfaces__vrf` jpath for `cisco_xe.yml`, so the canonical Nautobot interface name `Vlan100` correctly maps to the `VLAN100` form emitted by the ntc-templates `cisco_xe_show_ip_vrf_interfaces` parser.
- Without this, VRF assignments on VLAN SVI interfaces were silently dropped during `Sync Network Data From Network` — the filter defaulted to `Vlan100 → Vl100`, which matched neither the textfsm output nor the Nautobot interface name.

## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design