### PR TITLE
Fix Sync Device Job to raise if platform auto-discovery fails (ltm)

### DIFF
--- a/changes/581.fixed
+++ b/changes/581.fixed
@@ -1,0 +1,1 @@
+Fix Sync Device Job to raise if platform auto-discovery fails and fail_job_on_task_failure is set to True.

--- a/nautobot_device_onboarding/nornir_plays/command_getter.py
+++ b/nautobot_device_onboarding/nornir_plays/command_getter.py
@@ -338,6 +338,10 @@ def sync_devices_command_getter(job, log_level):
                         logger.error(
                             f"Unable to onboard {values['original_ip_address']}, failed with exception {exc_info}"
                         )
+                        if job.fail_job_on_task_failure:
+                            raise RuntimeError(
+                                f"Unable to onboard {values['original_ip_address']}, failed with exception {exc_info}."
+                            ) from exc_info
                         continue
                 nr_with_processors.inventory.hosts.update(single_host_inventory_constructed)
             result = nr_with_processors.run(

--- a/nautobot_device_onboarding/tests/test_sync_devices_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_devices_adapters.py
@@ -119,6 +119,48 @@ class SyncDevicesNetworkAdapterTestCase(TransactionTestCase):
         result = sync_devices_command_getter(job=self.job, log_level="INFO")
         self.assertEqual(result, {})
 
+    @patch("nautobot_device_onboarding.nornir_plays.command_getter.InitNornir")
+    @patch("nautobot_device_onboarding.nornir_plays.command_getter._set_inventory")
+    def test_command_getter_set_inventory_exc_info_respects_fail_job_on_task_failure(self, set_inventory, init_nornir):
+        """When _set_inventory returns an exception, the host is skipped unless fail_job_on_task_failure raises."""
+        # Simulate a host that fails inventory construction (e.g. no connectivity / autodetection failure):
+        # _set_inventory returns an empty inventory and a non-None exception.
+        set_inventory.return_value = ({}, Exception("Autodetection failed"))
+
+        nornir_obj = MagicMock()
+        nr_with_processors = MagicMock()
+        nornir_obj.with_processors.return_value = nr_with_processors
+        # The task run itself does not fail; only inventory construction did.
+        nr_with_processors.run.return_value = SimpleNamespace(failed=False, failed_hosts={})
+        init_nornir.return_value.__enter__.return_value = nornir_obj
+
+        processed_ip_address_attrs = {
+            "original_ip_address": "10.1.1.10",
+            "location": self.testing_objects["location"],
+            "namespace": self.testing_objects["namespace"],
+            "port": 22,
+            "timeout": 30,
+            "update_devices_without_primary_ip": True,
+            "device_role": self.testing_objects["device_role"],
+            "device_status": self.testing_objects["status"],
+            "device_tenant": self.testing_objects["device_tenant_1"],
+            "interface_status": self.testing_objects["status"],
+            "ip_address_status": self.testing_objects["status"],
+            "secrets_group": self.testing_objects["secrets_group"],
+            "platform": None,
+        }
+        self.job.ip_address_inventory = {"10.1.1.10": processed_ip_address_attrs}
+
+        with self.subTest(fail_job_on_task_failure=True):
+            self.job.fail_job_on_task_failure = True
+            with self.assertRaises(RuntimeError):
+                sync_devices_command_getter(job=self.job, log_level="INFO")
+
+        with self.subTest(fail_job_on_task_failure=False):
+            self.job.fail_job_on_task_failure = False
+            result = sync_devices_command_getter(job=self.job, log_level="INFO")
+            self.assertEqual(result, {})
+
 
 class SyncDevicesNautobotAdapterTestCase(TransactionTestCase):
     """Test SyncDevicesNautobotAdapter class."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #581 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

----- This is the ltm counterpart of [582](https://github.com/nautobot/nautobot-app-device-onboarding/pull/582) -----

Added Job raise when exception occurs during device platform auto-discovery, provided that fail_job_on_task_failure flag is set to True.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
