### PR TITLE
Add opt-in config context enrichment to Sync Network Data

### DIFF
--- a/changes/595.added
+++ b/changes/595.added
@@ -1,0 +1,1 @@
+Added an opt-in "Sync Config Context" option to the Sync Network Data From Network job that collects supplemental show-command data declared under a `config_context` key in the command mapper and writes it to each device's local config context under a managed `device_onboarding` key.

--- a/docs/user/app_use_cases.md
+++ b/docs/user/app_use_cases.md
@@ -342,6 +342,36 @@ Required Fields:
     devices: Location UUID
 
 
+### Onboarding Supplemental Data into Config Context
+
+The `Sync Network Data From Network` job can collect additional show-command data that Nautobot does not model natively (for example OSPF neighbors or SNMP communities) and write it to each device's local config context. This is opt-in via the `Sync Config Context` checkbox on the job form.
+
+To collect a piece of data, add a `config_context` key to the platform's command mapper under `sync_network_data`. Each entry beneath it is a named subfield following the same `commands` / `parser` / `jpath` / `post_processor` / `iterable_type` contract as any other mapper field:
+
+```yaml
+sync_network_data:
+  config_context:
+    ip_ospf_neighbors:
+      commands:
+        - command: "show ip ospf neighbor"
+          parser: "textfsm"
+          jpath: "[*].{neighbor_id: neighbor_id, ip_address: ip_address, interface: interface, state: state}"
+          post_processor: "{{ obj | sort(attribute='neighbor_id') | list | tojson }}"
+          iterable_type: "list"
+```
+
+When the job runs with `Sync Config Context` enabled, the collected data is written to the device's local config context under a single managed top-level key, `device_onboarding`:
+
+```json
+{
+  "device_onboarding": {
+    "ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1", "ip_address": "10.0.0.1", "interface": "GigabitEthernet0/0", "state": "FULL/BDR"}]
+  }
+}
+```
+
+This behavior is additive: only the `device_onboarding` key is read, compared, and written. Any other keys in the device's local config context (for example data sourced from a Git repository or entered manually) are preserved, and the job never deletes config context. For predictable diffs across repeated syncs, sort list output deterministically in the `post_processor` (as shown above). If the device has a Config Context Schema assigned, the merged local config context must still satisfy it.
+
 ### Using Git(Datasources) to Override the Apps Defaults
 
 #### YAML Overrides

--- a/nautobot_device_onboarding/constants.py
+++ b/nautobot_device_onboarding/constants.py
@@ -25,6 +25,13 @@ NETMIKO_TO_NAPALM_STATIC = {
 # This is used in the new SSoT based jobs. Soon PYATS should be supported.
 SUPPORTED_COMMAND_PARSERS = ["textfsm", "ttp"]
 
+# Sync Network Data config-context enrichment. Supplemental show-command data declared under
+# the `config_context` mapper key is written to a Device's local config context under a single
+# managed top-level key (local_config_context_data[MANAGED_OWNER_KEY]), so this app only ever
+# reads/diffs/writes its own slice and never collides with other config-context sources
+# (Git data sources, manual entry, or scoped ConfigContext objects).
+MANAGED_OWNER_KEY = "device_onboarding"
+
 # This should potentially be removed and used nautobot core directly choices.
 # from nautobot.dcim.choices import InterfaceTypeChoices
 # InterfaceTypeChoices.as_dict() doesn't directly fit yet.  Seems like maybe netutils needs the "human readible" nb choices.

--- a/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/diffsync/adapters/sync_network_data_adapters.py
@@ -16,6 +16,7 @@ from nautobot_ssot.contrib import NautobotAdapter
 from netaddr import EUI, mac_unix_expanded
 from netutils.interface import canonical_interface_name
 
+from nautobot_device_onboarding.constants import MANAGED_OWNER_KEY
 from nautobot_device_onboarding.diffsync.models import sync_network_data_models
 from nautobot_device_onboarding.nornir_plays.command_getter import (
     sync_network_data_command_getter,
@@ -58,6 +59,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
     cable = sync_network_data_models.SyncNetworkDataCable
     software_version = sync_network_data_models.SyncNetworkSoftwareVersion
     software_version_to_device = sync_network_data_models.SyncNetworkSoftwareVersionToDevice
+    config_context = sync_network_data_models.SyncNetworkDataConfigContext
 
     primary_ips = None
 
@@ -75,6 +77,7 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
         "cable",
         "software_version",
         "software_version_to_device",
+        "config_context",
     ]
 
     def _cache_primary_ips(self, device_queryset):
@@ -384,6 +387,23 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
             network_software_version_to_device.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
             self.add(network_software_version_to_device)
 
+    def load_config_context(self):
+        """Load the device-onboarding-managed config context slice from each device.
+
+        Reads ONLY local_config_context_data[MANAGED_OWNER_KEY] so the diff is bounded to this
+        app's namespace — other config-context sources (Git data sources, manual entry, scoped
+        ConfigContext objects) never enter the comparison. Scoped to devices_to_load.
+        """
+        for device in self.job.devices_to_load:
+            managed = (device.local_config_context_data or {}).get(MANAGED_OWNER_KEY, {})
+            config_context = self.config_context(
+                adapter=self,
+                device__name=device.name,
+                data=managed or {},
+            )
+            config_context.model_flags = DiffSyncModelFlags.SKIP_UNMATCHED_DST
+            self.add(config_context)
+
     def _handle_single_parameter(self, parameters, parameter_name, database_object, diffsync_model):
         """Overload parameter handling to add special handling for modular interfaces."""
         if parameter_name == "device__name":
@@ -437,6 +457,9 @@ class SyncNetworkDataNautobotAdapter(FilteredNautobotAdapter):
             elif model_name == "software_version_to_device":
                 if self.job.sync_software_version:
                     self.load_software_version_to_device()
+            elif model_name == "config_context":
+                if self.job.sync_config_context:
+                    self.load_config_context()
             else:
                 diffsync_model = self._get_diffsync_class(model_name)
                 self._load_objects(diffsync_model)
@@ -518,6 +541,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
     cable = sync_network_data_models.SyncNetworkDataCable
     software_version = sync_network_data_models.SyncNetworkSoftwareVersion
     software_version_to_device = sync_network_data_models.SyncNetworkSoftwareVersionToDevice
+    config_context = sync_network_data_models.SyncNetworkDataConfigContext
 
     top_level = [
         "ip_address",
@@ -533,6 +557,7 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
         "cable",
         "software_version",
         "software_version_to_device",
+        "config_context",
     ]
 
     def _handle_failed_devices(self, device_data):
@@ -1145,6 +1170,25 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
                 except diffsync.exceptions.ObjectAlreadyExists:
                     continue
 
+    def load_config_context(self):
+        """Load supplemental config-context data collected from each device.
+
+        Iterates the pruned command_getter_result (after _exclude_filtered_out_devices), so
+        excluded/serial-drifted devices never contribute config context.
+        """
+        for hostname, device_data in self.job.command_getter_result.items():
+            if self.job.debug:
+                self.job.logger.debug(f"Loading config context from {hostname}")
+            try:
+                config_context = self.config_context(
+                    adapter=self,
+                    device__name=hostname,
+                    data=device_data.get("config_context", {}),
+                )
+                self.add(config_context)
+            except diffsync.exceptions.ObjectAlreadyExists:
+                continue
+
     def load(self):
         """Load network data."""
         self.execute_command_getter()
@@ -1170,3 +1214,5 @@ class SyncNetworkDataNetworkAdapter(diffsync.Adapter):
             self.load_software_versions()
         if self.job.sync_software_version:
             self.load_software_version_to_device()
+        if self.job.sync_config_context:
+            self.load_config_context()

--- a/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
+++ b/nautobot_device_onboarding/diffsync/models/sync_network_data_models.py
@@ -18,7 +18,10 @@ from nautobot.extras.models import Status
 from nautobot.ipam.models import VLAN, VRF, IPAddress, IPAddressToInterface, Namespace, Prefix
 from nautobot_ssot.contrib import CustomFieldAnnotation, NautobotModel
 
-from nautobot_device_onboarding.constants import ONBOARDING_DEVICE_MODULE_RECURSION_LIMIT
+from nautobot_device_onboarding.constants import (
+    MANAGED_OWNER_KEY,
+    ONBOARDING_DEVICE_MODULE_RECURSION_LIMIT,
+)
 from nautobot_device_onboarding.utils import diffsync_utils
 
 
@@ -848,4 +851,65 @@ class SyncNetworkSoftwareVersionToDevice(DiffSyncModel):
 
     def delete(self):
         """Prevent device deletion."""
+        return None
+
+
+class SyncNetworkDataConfigContext(DiffSyncModel):
+    """Shared data model representing the device-onboarding-managed local config context slice.
+
+    Supplemental show-command data declared under the `config_context` mapper key is written to
+    a Device under a single managed top-level key, local_config_context_data[MANAGED_OWNER_KEY]
+    (i.e. `device_onboarding`). Only this app's key is read, diffed, and written; every other
+    top-level key on the device (Git-sourced, manual, scoped contexts) is preserved.
+
+    Additive-only: delete() is a no-op so a sync can never strip a device's config context.
+    """
+
+    _modelname = "config_context"
+    _model = Device
+    _identifiers = ("device__name",)
+    _attributes = ("data",)
+
+    device__name: str
+    data: Optional[dict] = None
+
+    @classmethod
+    def _write(cls, adapter, device_name, data, not_saved_exc):
+        """Write the managed blob to the device's local config context under MANAGED_OWNER_KEY."""
+        try:
+            device = adapter.job.devices_to_load.get(name=device_name)
+        except ObjectDoesNotExist as err:
+            adapter.job.logger.error(
+                "Failed to write config context to %s. No matching device in the job's filter set.", device_name
+            )
+            raise not_saved_exc(err)
+        local_data = device.local_config_context_data or {}
+        local_data[MANAGED_OWNER_KEY] = data or {}
+        device.local_config_context_data = local_data
+        try:
+            device.validated_save()
+        except ValidationError as err:
+            adapter.job.logger.error(f"Failed to write config context to device [{device_name}], {err}")
+            raise not_saved_exc(err)
+
+    @classmethod
+    def create(cls, adapter, ids, attrs):
+        """Write the managed config-context blob to the device."""
+        cls._write(adapter, ids["device__name"], attrs.get("data"), diffsync_exceptions.ObjectNotCreated)
+        return super().create(adapter, ids, attrs)
+
+    def update(self, attrs):
+        """Replace the managed config-context blob on the device."""
+        if "data" in attrs:
+            self._write(
+                self.adapter,
+                self.get_identifiers()["device__name"],
+                attrs["data"],
+                diffsync_exceptions.ObjectNotUpdated,
+            )
+        return super().update(attrs)
+
+    def delete(self):
+        """Prevent config-context deletion (additive-only contract)."""
+        self.adapter.job.logger.warning(f"{self} config context will not be deleted.")
         return None

--- a/nautobot_device_onboarding/jobs.py
+++ b/nautobot_device_onboarding/jobs.py
@@ -640,6 +640,14 @@ class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attr
     )
     sync_cables = BooleanVar(default=False, description="Sync cables between interfaces via a LLDP or CDP.")
     sync_software_version = BooleanVar(default=False, description="Sync software version from device.")
+    sync_config_context = BooleanVar(
+        default=False,
+        description=(
+            "Collect supplemental show-command data declared under the `config_context` key in the command "
+            "mapper and write it to each device's local config context, under a managed "
+            "`device_onboarding` key. Additive; only this app's key is read or written."
+        ),
+    )
     update_devices_with_changed_serial = BooleanVar(
         default=False,
         description="If a device at the specified location already exists in Nautobot but the serial number "
@@ -728,6 +736,7 @@ class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attr
         interface_status,
         ip_address_status,
         default_prefix_status,
+        sync_config_context=False,
         parallel_loading=False,
         devices=None,
         location=None,
@@ -745,6 +754,7 @@ class SSOTSyncNetworkData(DataSource):  # pylint: disable=too-many-instance-attr
         self.sync_vrf_to_prefix = sync_vrf_to_prefix
         self.sync_cables = sync_cables
         self.sync_software_version = sync_software_version
+        self.sync_config_context = sync_config_context
         self.update_devices_with_changed_serial = update_devices_with_changed_serial
         self.namespace = namespace
         self.interface_status = interface_status

--- a/nautobot_device_onboarding/nornir_plays/command_getter.py
+++ b/nautobot_device_onboarding/nornir_plays/command_getter.py
@@ -64,7 +64,9 @@ def deduplicate_command_list(data):
     return unique_list
 
 
-def _get_commands_to_run(yaml_parsed_info, sync_vlans, sync_vrfs, sync_cables, sync_software_version):
+def _get_commands_to_run(
+    yaml_parsed_info, sync_vlans, sync_vrfs, sync_cables, sync_software_version, sync_config_context=False
+):
     """Using merged command mapper info and look up all commands that need to be run."""
     all_commands = []
     for key, value in yaml_parsed_info.items():
@@ -80,6 +82,16 @@ def _get_commands_to_run(yaml_parsed_info, sync_vlans, sync_vrfs, sync_cables, s
                 else:
                     if isinstance(current_root_key, dict):
                         all_commands.append(current_root_key)
+        elif key == "config_context":
+            # config_context's value is a map of subfields, each holding its own command(s).
+            if not sync_config_context:
+                continue
+            for _subfield, subdef in value.items():
+                sub_commands = subdef.get("commands")
+                if isinstance(sub_commands, list):
+                    all_commands.extend(sub_commands)
+                elif isinstance(sub_commands, dict):
+                    all_commands.append(sub_commands)
         else:
             # Deduplicate commands + parser key
             current_root_key = value.get("commands")
@@ -141,6 +153,7 @@ def netmiko_send_commands(task: Task, command_getter_yaml_data: Dict, command_ge
         getattr(nautobot_job, "sync_vrfs", False),
         getattr(nautobot_job, "sync_cables", False),
         getattr(nautobot_job, "sync_software_version", False),
+        getattr(nautobot_job, "sync_config_context", False),
     )
     if (
         getattr(nautobot_job, "sync_cables", False)
@@ -387,6 +400,7 @@ def sync_network_data_command_getter(job, log_level):
                         "sync_vrfs": job.sync_vrfs,
                         "sync_cables": job.sync_cables,
                         "sync_software_version": job.sync_software_version,
+                        "sync_config_context": job.sync_config_context,
                     },
                 },
             },

--- a/nautobot_device_onboarding/nornir_plays/formatter.py
+++ b/nautobot_device_onboarding/nornir_plays/formatter.py
@@ -128,6 +128,7 @@ def perform_data_extraction(host, command_info_dict, command_outputs_dict, job_d
     sync_vrfs = host.defaults.data.get("sync_vrfs", False)
     sync_cables = host.defaults.data.get("sync_cables", False)
     sync_software_version = host.defaults.data.get("sync_software_version", False)
+    sync_config_context = host.defaults.data.get("sync_config_context", False)
     get_context_from_pre_processor = {}
     if command_info_dict.get("pre_processor"):
         for pre_processor_name, field_data in command_info_dict["pre_processor"].items():
@@ -159,6 +160,31 @@ def perform_data_extraction(host, command_info_dict, command_outputs_dict, job_d
         if not sync_software_version and ssot_field == "software_version":
             continue
         if ssot_field == "pre_processor":
+            continue
+        if ssot_field == "config_context":
+            # config_context holds a map of independent subfields, each with its own command(s).
+            # Collect them under a single "config_context" key; the consumer namespaces it on write.
+            if sync_config_context:
+                result_dict["config_context"] = {}
+                for subfield, subdef in field_data.items():
+                    sub_commands = subdef["commands"]
+                    if isinstance(sub_commands, dict):
+                        sub_commands = [sub_commands]
+                    for show_command_dict in sub_commands:
+                        # A device may not support every config_context command (no OSPF, no SNMP,
+                        # unsupported platform command). A failed/absent command is missing from
+                        # command_outputs_dict; .get() yields None, which extract_and_post_process
+                        # normalizes to an empty result for the declared iterable_type instead of
+                        # raising KeyError and aborting extraction for the whole host.
+                        command_output = command_outputs_dict.get(show_command_dict["command"])
+                        _, current_field_post = extract_and_post_process(
+                            command_output,
+                            show_command_dict,
+                            {"obj": host.name, "original_host": host.name},
+                            show_command_dict.get("iterable_type"),
+                            job_debug,
+                        )
+                        result_dict["config_context"][subfield] = current_field_post
             continue
         if isinstance(field_data["commands"], dict):
             # only one command is specified as a dict force it to a list.

--- a/nautobot_device_onboarding/tests/mock/command_mappers/mock_cisco_ios.yml
+++ b/nautobot_device_onboarding/tests/mock/command_mappers/mock_cisco_ios.yml
@@ -121,3 +121,18 @@ sync_network_data:
       - command: "show cdp neighbors detail"
         parser: "textfsm"
         jpath: "[*].{local_interface:local_interface, remote_interface:neighbor_interface, remote_device:neighbor_name}"
+  config_context:
+    ip_ospf_neighbors:
+      commands:
+        - command: "show ip ospf neighbor"
+          parser: "textfsm"
+          jpath: "[*].{neighbor_id: neighbor_id, ip_address: ip_address, interface: interface, state: state}"
+          post_processor: "{{ obj | sort(attribute='neighbor_id') | list | tojson }}"
+          iterable_type: "list"
+    snmp_communities:
+      commands:
+        - command: "show running-config | include snmp-server community"
+          parser: "raw"
+          jpath: "raw"
+          post_processor: "{% set result=[] %}{% for line in obj.splitlines() %}{% set entry=line|trim %}{% if entry %}{{ result.append({'community': entry}) or '' }}{% endif %}{% endfor %}{{ result | sort(attribute='community') | list | tojson }}"
+          iterable_type: "list"

--- a/nautobot_device_onboarding/tests/test_command_getter.py
+++ b/nautobot_device_onboarding/tests/test_command_getter.py
@@ -239,6 +239,33 @@ class TestGetCommandsToRun(unittest.TestCase):
         ]
         self.assertEqual(get_commands_to_run, expected_commands_to_run)
 
+    def test_deduplicate_command_list_sync_data_config_context(self):
+        """With sync_config_context on, the config_context subfield commands are included."""
+        get_commands_to_run = _get_commands_to_run(
+            self.expected_data["sync_network_data"],
+            sync_vlans=False,
+            sync_vrfs=False,
+            sync_cables=False,
+            sync_software_version=False,
+            sync_config_context=True,
+        )
+        commands = [command["command"] for command in get_commands_to_run]
+        self.assertIn("show ip ospf neighbor", commands)
+        self.assertIn("show running-config | include snmp-server community", commands)
+
+    def test_deduplicate_command_list_sync_data_no_config_context(self):
+        """With sync_config_context off (default), the config_context commands are excluded."""
+        get_commands_to_run = _get_commands_to_run(
+            self.expected_data["sync_network_data"],
+            sync_vlans=False,
+            sync_vrfs=False,
+            sync_cables=False,
+            sync_software_version=False,
+        )
+        commands = [command["command"] for command in get_commands_to_run]
+        self.assertNotIn("show ip ospf neighbor", commands)
+        self.assertNotIn("show running-config | include snmp-server community", commands)
+
 
 @patch("nautobot_device_onboarding.nornir_plays.command_getter.NornirLogger", MagicMock())
 class TestSSHCredParsing(TransactionTestCase):

--- a/nautobot_device_onboarding/tests/test_formatter.py
+++ b/nautobot_device_onboarding/tests/test_formatter.py
@@ -844,3 +844,111 @@ class TestFormatterSyncNetworkDataWithSoftware(unittest.TestCase):
                                 job_debug=False,
                             )
                             self.assertEqual(expected_parsed_result, actual_result)
+
+
+class TestFormatterSyncNetworkDataConfigContext(unittest.TestCase):
+    """Tests for the config_context reserved-key extraction in perform_data_extraction."""
+
+    def setUp(self):
+        # Only the config_context section is exercised. The shipped mappers intentionally do not
+        # include a config_context block, so source it from the mock cisco_ios mapper fixture.
+        with open(
+            os.path.join(MOCK_DIR, "command_mappers", "mock_cisco_ios.yml"), "r", encoding="utf-8"
+        ) as mapper_file:
+            mock_mapper = yaml.safe_load(mapper_file)
+        self.config_context_mapper = {"config_context": mock_mapper["sync_network_data"]["config_context"]}
+        self.command_outputs = {
+            "show ip ospf neighbor": [
+                {
+                    "neighbor_id": "2.2.2.2",
+                    "priority": "1",
+                    "state": "FULL/DR",
+                    "dead_time": "00:00:39",
+                    "ip_address": "10.0.0.2",
+                    "interface": "GigabitEthernet0/1",
+                },
+                {
+                    "neighbor_id": "1.1.1.1",
+                    "priority": "1",
+                    "state": "FULL/BDR",
+                    "dead_time": "00:00:38",
+                    "ip_address": "10.0.0.1",
+                    "interface": "GigabitEthernet0/0",
+                },
+            ],
+            # parser: raw stores the output under a "raw" key.
+            "show running-config | include snmp-server community": {
+                "raw": "snmp-server community public RO\nsnmp-server community private RW\n"
+            },
+        }
+
+    def _make_host(self, sync_config_context):
+        return Host(
+            name="198.51.100.1",
+            hostname="198.51.100.1",
+            port=22,
+            username="username",
+            password="password",  # nosec
+            platform="cisco_ios",
+            defaults=Defaults(data={"sync_config_context": sync_config_context}),
+        )
+
+    def test_config_context_extracted_when_enabled(self):
+        host = self._make_host(sync_config_context=True)
+        result = perform_data_extraction(host, self.config_context_mapper, self.command_outputs, job_debug=False)
+        expected = {
+            "config_context": {
+                "ip_ospf_neighbors": [
+                    {
+                        "neighbor_id": "1.1.1.1",
+                        "ip_address": "10.0.0.1",
+                        "interface": "GigabitEthernet0/0",
+                        "state": "FULL/BDR",
+                    },
+                    {
+                        "neighbor_id": "2.2.2.2",
+                        "ip_address": "10.0.0.2",
+                        "interface": "GigabitEthernet0/1",
+                        "state": "FULL/DR",
+                    },
+                ],
+                "snmp_communities": [
+                    {"community": "snmp-server community private RW"},
+                    {"community": "snmp-server community public RO"},
+                ],
+            }
+        }
+        self.assertEqual(expected, result)
+
+    def test_config_context_omitted_when_disabled(self):
+        host = self._make_host(sync_config_context=False)
+        result = perform_data_extraction(host, self.config_context_mapper, self.command_outputs, job_debug=False)
+        self.assertNotIn("config_context", result)
+
+    def test_config_context_is_json_round_trippable(self):
+        host = self._make_host(sync_config_context=True)
+        result = perform_data_extraction(host, self.config_context_mapper, self.command_outputs, job_debug=False)
+        self.assertEqual(json.loads(json.dumps(result)), result)
+
+    def test_config_context_empty_when_device_has_no_data(self):
+        """A device with no OSPF neighbors / no SNMP communities yields stable empty subfields."""
+        host = self._make_host(sync_config_context=True)
+        empty_outputs = {
+            "show ip ospf neighbor": [],
+            "show running-config | include snmp-server community": {"raw": ""},
+        }
+        result = perform_data_extraction(host, self.config_context_mapper, empty_outputs, job_debug=False)
+        self.assertEqual(result, {"config_context": {"ip_ospf_neighbors": [], "snmp_communities": []}})
+        # The empty shape must round-trip so the next sync diffs clean instead of perpetually updating.
+        self.assertEqual(json.loads(json.dumps(result)), result)
+
+    def test_config_context_missing_command_output_does_not_raise(self):
+        """A subfield whose command failed/was not returned is skipped to an empty result, not a KeyError."""
+        host = self._make_host(sync_config_context=True)
+        # The SNMP command output is absent entirely (command failed or unsupported on the device).
+        partial_outputs = {"show ip ospf neighbor": self.command_outputs["show ip ospf neighbor"]}
+        result = perform_data_extraction(host, self.config_context_mapper, partial_outputs, job_debug=False)
+        # The missing subfield normalizes to an empty list...
+        self.assertEqual(result["config_context"]["snmp_communities"], [])
+        # ...while the subfield that did return data is still populated.
+        self.assertEqual(len(result["config_context"]["ip_ospf_neighbors"]), 2)

--- a/nautobot_device_onboarding/tests/test_jobs.py
+++ b/nautobot_device_onboarding/tests/test_jobs.py
@@ -324,6 +324,110 @@ class SSOTSyncNetworkDataTestCase(TransactionTestCase):
                     self.assertEqual(interface.vrf.name, interface_data["vrf"]["name"])
 
     @patch("nautobot_device_onboarding.diffsync.adapters.sync_network_data_adapters.sync_network_data_command_getter")
+    def test_sync_network_data_config_context(self, device_data):
+        """With sync_config_context on, collected data is written to the device's local config context."""
+        # Shallow-merge a config_context blob onto one device without mutating the shared fixture.
+        mock_data = dict(sync_network_data_fixture.sync_network_mock_data_valid)
+        mock_data["demo-cisco-1"] = {
+            **mock_data["demo-cisco-1"],
+            "config_context": {"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]},
+        }
+        device_data.return_value = mock_data
+        devices = ["demo-cisco-1", "demo-cisco-2", "demo-cisco-4"]
+        device_ids_to_sync = list(Device.objects.filter(name__in=devices).values_list("id", flat=True))
+
+        job_form_inputs = {
+            "debug": True,
+            "connectivity_test": False,
+            "dryrun": False,
+            "sync_vlans": False,
+            "sync_vrfs": False,
+            "sync_vrf_to_prefix": False,
+            "sync_cables": False,
+            "sync_software_version": False,
+            "sync_config_context": True,
+            "update_devices_with_changed_serial": False,
+            "namespace": self.testing_objects["namespace"].pk,
+            "interface_status": self.testing_objects["status"].pk,
+            "ip_address_status": self.testing_objects["status"].pk,
+            "default_prefix_status": self.testing_objects["status"].pk,
+            "devices": device_ids_to_sync,
+            "location": None,
+            "device_role": None,
+            "platform": None,
+            "memory_profiling": False,
+            "fail_job_on_task_failure": False,
+        }
+        job_result = create_job_result_and_run_job(
+            module="nautobot_device_onboarding.jobs", name="SSOTSyncNetworkData", **job_form_inputs
+        )
+
+        self.assertEqual(
+            job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
+        )
+        device = Device.objects.get(name="demo-cisco-1")
+        self.assertEqual(
+            device.local_config_context_data["device_onboarding"],
+            {"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]},
+        )
+
+    @patch("nautobot_device_onboarding.diffsync.adapters.sync_network_data_adapters.sync_network_data_command_getter")
+    def test_sync_network_data_config_context_disabled_leaves_existing_key_untouched(self, device_data):
+        """With sync_config_context off, an existing managed key is neither updated nor deleted."""
+        # Pre-seed the device with a managed slice and an unrelated sibling key.
+        existing = {"device_onboarding": {"ip_ospf_neighbors": [{"neighbor_id": "0.0.0.0"}]}, "manual": "keep"}
+        device = Device.objects.get(name="demo-cisco-1")
+        device.local_config_context_data = dict(existing)
+        device.validated_save()
+
+        # The source still reports fresh config context; with the flag off it must be ignored entirely.
+        mock_data = dict(sync_network_data_fixture.sync_network_mock_data_valid)
+        mock_data["demo-cisco-1"] = {
+            **mock_data["demo-cisco-1"],
+            "config_context": {"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]},
+        }
+        device_data.return_value = mock_data
+        devices = ["demo-cisco-1", "demo-cisco-2", "demo-cisco-4"]
+        device_ids_to_sync = list(Device.objects.filter(name__in=devices).values_list("id", flat=True))
+
+        job_form_inputs = {
+            "debug": True,
+            "connectivity_test": False,
+            "dryrun": False,
+            "sync_vlans": False,
+            "sync_vrfs": False,
+            "sync_vrf_to_prefix": False,
+            "sync_cables": False,
+            "sync_software_version": False,
+            "sync_config_context": False,
+            "update_devices_with_changed_serial": False,
+            "namespace": self.testing_objects["namespace"].pk,
+            "interface_status": self.testing_objects["status"].pk,
+            "ip_address_status": self.testing_objects["status"].pk,
+            "default_prefix_status": self.testing_objects["status"].pk,
+            "devices": device_ids_to_sync,
+            "location": None,
+            "device_role": None,
+            "platform": None,
+            "memory_profiling": False,
+            "fail_job_on_task_failure": False,
+        }
+        job_result = create_job_result_and_run_job(
+            module="nautobot_device_onboarding.jobs", name="SSOTSyncNetworkData", **job_form_inputs
+        )
+
+        self.assertEqual(
+            job_result.status,
+            JobResultStatusChoices.STATUS_SUCCESS,
+            (job_result.traceback, list(job_result.job_log_entries.values_list("message", flat=True))),
+        )
+        device.refresh_from_db()
+        # The managed slice is untouched (not overwritten with the source data) and the sibling survives.
+        self.assertEqual(device.local_config_context_data, existing)
+
+    @patch("nautobot_device_onboarding.diffsync.adapters.sync_network_data_adapters.sync_network_data_command_getter")
     def test_update_devices_with_changed_serial_toggle__absorbs_serial_drift(self, device_data):
         """With update_devices_with_changed_serial=True, a serial-drifted device's row gets
         its serial updated and its interfaces enriched in a single SND run.

--- a/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
+++ b/nautobot_device_onboarding/tests/test_sync_network_data_adapters.py
@@ -1,5 +1,6 @@
 """Test Cisco Support adapter."""
 
+import copy
 from unittest.mock import MagicMock, patch
 
 from django.contrib.contenttypes.models import ContentType
@@ -309,6 +310,15 @@ class SyncNetworkDataNetworkAdapterTestCase(TransactionTestCase):
             diffsync_obj = self.sync_network_data_adapter.get("software_version_to_device", unique_id)
             self.assertEqual(device_data["software_version"], diffsync_obj.software_version__version)
 
+    def test_load_config_context(self):
+        """Network adapter loads collected config_context blobs into the diffsync store."""
+        self.job.command_getter_result["demo-cisco-1"]["config_context"] = {
+            "ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]
+        }
+        self.sync_network_data_adapter.load_config_context()
+        diffsync_obj = self.sync_network_data_adapter.get("config_context", "demo-cisco-1")
+        self.assertEqual(diffsync_obj.data, {"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]})
+
 
 class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
     """Test SyncNetworkDataNautobotAdapter class."""
@@ -508,3 +518,98 @@ class SyncNetworkDataNautobotAdapterTestCase(TransactionTestCase):
                 self.sync_network_data_adapter.primary_ips[device.id],
                 device.primary_ip.id if device.primary_ip else None,
             )
+
+    def test_load_config_context_reads_only_managed_slice(self):
+        """Nautobot adapter loads only the device_onboarding slice, ignoring other top-level keys."""
+        device = Device.objects.get(name="demo-cisco-1")
+        device.local_config_context_data = {
+            "ntp": ["192.0.2.1"],
+            "device_onboarding": {"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]},
+        }
+        device.validated_save()
+
+        self.sync_network_data_adapter.load_config_context()
+
+        diffsync_obj = self.sync_network_data_adapter.get("config_context", "demo-cisco-1")
+        self.assertEqual(diffsync_obj.data, {"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]})
+
+    def test_config_context_create_preserves_unmanaged_keys(self):
+        """Writing the managed slice leaves sibling and other top-level keys intact."""
+        device = Device.objects.get(name="demo-cisco-1")
+        device.local_config_context_data = {
+            "ntp": ["192.0.2.1"],
+            "other_tool": {"foo": "bar"},
+            "device_onboarding": {"stale": True},
+        }
+        device.validated_save()
+
+        new_data = {"ip_ospf_neighbors": [{"neighbor_id": "2.2.2.2"}]}
+        self.sync_network_data_adapter.config_context.create(
+            self.sync_network_data_adapter, {"device__name": "demo-cisco-1"}, {"data": new_data}
+        )
+
+        device.refresh_from_db()
+        self.assertEqual(device.local_config_context_data["ntp"], ["192.0.2.1"])
+        self.assertEqual(device.local_config_context_data["other_tool"], {"foo": "bar"})
+        self.assertEqual(device.local_config_context_data["device_onboarding"], new_data)
+
+    def test_config_context_delete_is_noop(self):
+        """delete() never strips a device's config context (additive-only contract)."""
+        self.job.logger = MagicMock()
+        device = Device.objects.get(name="demo-cisco-1")
+        device.local_config_context_data = {"device_onboarding": {"x": 1}}
+        device.validated_save()
+
+        instance = self.sync_network_data_adapter.config_context(
+            adapter=self.sync_network_data_adapter, device__name="demo-cisco-1", data={"x": 1}
+        )
+        self.assertIsNone(instance.delete())
+
+        device.refresh_from_db()
+        self.assertEqual(device.local_config_context_data["device_onboarding"], {"x": 1})
+
+    def test_config_context_diff_is_idempotent(self):
+        """A device whose managed slice already equals the collected data produces no diff (no perpetual update)."""
+        blob = {
+            "ip_ospf_neighbors": [
+                {"neighbor_id": "1.1.1.1", "ip_address": "10.0.12.2", "interface": "Ethernet0/1", "state": "FULL/  -"}
+            ],
+            "snmp_communities": [{"community": "snmp-server community public RO"}],
+        }
+        device = Device.objects.get(name="demo-cisco-1")
+        device.local_config_context_data = {"device_onboarding": blob}
+        device.validated_save()
+
+        # Deep-copy the shared fixture before seeding the source side so the mutation doesn't leak.
+        self.job.command_getter_result = copy.deepcopy(sync_network_data_fixture.sync_network_mock_data_valid)
+        self.job.command_getter_result["demo-cisco-1"]["config_context"] = copy.deepcopy(blob)
+
+        nautobot_adapter = self.sync_network_data_adapter
+        nautobot_adapter.load_config_context()
+        network_adapter = SyncNetworkDataNetworkAdapter(job=self.job, sync=None)
+        network_adapter.load_config_context()
+
+        # Source (network) already equals destination (Nautobot): the config_context model must not diff.
+        diff = network_adapter.diff_to(nautobot_adapter)
+        self.assertFalse(diff.has_diffs(), diff.summary())
+
+    def test_config_context_update_replaces_managed_slice(self):
+        """update() swaps the managed slice for the latest collected data and leaves sibling keys intact."""
+        device = Device.objects.get(name="demo-cisco-1")
+        device.local_config_context_data = {
+            "manual": "keep",
+            "device_onboarding": {"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]},
+        }
+        device.validated_save()
+
+        new_data = {"ip_ospf_neighbors": [{"neighbor_id": "9.9.9.9"}]}
+        instance = self.sync_network_data_adapter.config_context(
+            adapter=self.sync_network_data_adapter,
+            device__name="demo-cisco-1",
+            data={"ip_ospf_neighbors": [{"neighbor_id": "1.1.1.1"}]},
+        )
+        instance.update({"data": new_data})
+
+        device.refresh_from_db()
+        self.assertEqual(device.local_config_context_data["device_onboarding"], new_data)
+        self.assertEqual(device.local_config_context_data["manual"], "keep")


### PR DESCRIPTION
# Closes: #595

## What's Changed

Adds an opt-in **Sync Config Context** option to the *Sync Network Data From
Network* job. When enabled, commands declared under a new reserved
`config_context` key in the command mapper are parsed through the normal mapper
pipeline and written to each device's `local_config_context_data` under a single
managed `device_onboarding` key.

This lets operators capture supplemental data Nautobot doesn't model natively
(OSPF neighbors, SNMP communities, …) declaratively in the mapper, without a
bespoke DiffSync model per data type.

- New `sync_config_context` BooleanVar (default off), threaded through the
  command getter and formatter like the other `sync_*` flags.
- New `SyncNetworkDataConfigContext` DiffSync model so the write goes through the
  SSoT diff — dry-run and diff stay accurate. Additive only: the managed
  `device_onboarding` key is owned and replaced each run; sibling, manual, and
  Git-sourced keys are preserved; `delete()` is a no-op.
- No `config_context` block ships in the default mappers — operators declare the
  commands they want. User docs show a worked example, and a mock mapper
  exercises it in the tests.

No migration and no new Nautobot model — `local_config_context_data` already
exists on `Device`.

**Declaring a command** — add a `config_context` block under `sync_network_data`
in the platform's command mapper; each subfield uses the normal
`commands / parser / jpath / post_processor / iterable_type` contract:

```yaml
sync_network_data:
  config_context:
    ip_ospf_neighbors:
      commands:
        - command: "show ip ospf neighbor"
          parser: "textfsm"
          jpath: "[*].{neighbor_id: neighbor_id, ip_address: ip_address, interface: interface, state: state}"
          post_processor: "{{ obj | sort(attribute='neighbor_id') | list | tojson }}"
          iterable_type: "list"
```

**Resulting payload** — with `Sync Config Context` enabled, this writes to the
device's local config context:

```json
{
  "device_onboarding": {
    "ip_ospf_neighbors": [
      {"neighbor_id": "1.1.1.1", "ip_address": "10.0.0.1", "interface": "GigabitEthernet0/0", "state": "FULL/BDR"}
    ]
  }
}
```

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

Remaining work / follow-ups: platform mappers can add their own `config_context`
blocks in follow-up PRs as coverage grows.
