### PR TITLE
Fixed Jobs to ensure the command mapper repo is synced before running

### DIFF
--- a/changes/609.fixed
+++ b/changes/609.fixed
@@ -1,0 +1,1 @@
+Fixed the Sync Devices and Sync Network Data jobs to ensure Git-provided command mappers are synced before running.

--- a/nautobot_device_onboarding/jobs.py
+++ b/nautobot_device_onboarding/jobs.py
@@ -848,6 +848,7 @@ class DeviceOnboardingTroubleshootingJob(Job):
                 logging={"enabled": False},
                 inventory={
                     "plugin": "empty-inventory",
+                    "options": {"logger": logger},
                 },
             ) as nornir_obj:
                 for entered_ip in ip_addresses:

--- a/nautobot_device_onboarding/nornir_plays/command_getter.py
+++ b/nautobot_device_onboarding/nornir_plays/command_getter.py
@@ -316,6 +316,10 @@ def sync_devices_command_getter(job, log_level):
             logging={"enabled": False},
             inventory={
                 "plugin": "empty-inventory",
+                "options": {
+                    "logger": logger,
+                    "raise_on_repo_error": job.fail_job_on_task_failure,
+                },
             },
         ) as nornir_obj:
             nr_with_processors = nornir_obj.with_processors([CommandGetterProcessor(logger, compiled_results, job)])
@@ -385,7 +389,9 @@ def sync_network_data_command_getter(job, log_level):
                     "credentials_class": NORNIR_SETTINGS.get("credentials"),
                     "queryset": qs,
                     "defaults": {
-                        "platform_parsing_info": add_platform_parsing_info(),
+                        "platform_parsing_info": add_platform_parsing_info(
+                            logger=logger, raise_on_repo_error=job.fail_job_on_task_failure
+                        ),
                         "network_driver_mappings": list(get_all_network_driver_mappings().keys()),
                         "sync_vlans": job.sync_vlans,
                         "sync_vrfs": job.sync_vrfs,

--- a/nautobot_device_onboarding/nornir_plays/empty_inventory.py
+++ b/nautobot_device_onboarding/nornir_plays/empty_inventory.py
@@ -9,12 +9,25 @@ from nautobot_device_onboarding.nornir_plays.transform import add_platform_parsi
 class EmptyInventory:  # pylint: disable=too-few-public-methods
     """Creates an empty Nornir inventory."""
 
+    def __init__(self, logger=None, raise_on_repo_error=False):
+        """Initialize the inventory plugin.
+
+        Args:
+            logger (NornirLogger): Optional logger to write results to the job result log.
+            raise_on_repo_error (bool): Fail instead of falling back to the app provided defaults
+                when the command mappers Git repository cannot be refreshed or read.
+        """
+        self.logger = logger
+        self.raise_on_repo_error = raise_on_repo_error
+
     def load(self) -> Inventory:
         """Create a default empty inventory."""
         hosts = Hosts()
         defaults = Defaults(
             data={
-                "platform_parsing_info": add_platform_parsing_info(),
+                "platform_parsing_info": add_platform_parsing_info(
+                    logger=self.logger, raise_on_repo_error=self.raise_on_repo_error
+                ),
                 "network_driver_mappings": list(get_all_network_driver_mappings().keys()),
             }
         )

--- a/nautobot_device_onboarding/nornir_plays/transform.py
+++ b/nautobot_device_onboarding/nornir_plays/transform.py
@@ -1,15 +1,19 @@
 """Adds command mapper, platform parsing info."""
 
+import logging
 import os
 
 import yaml
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from nautobot.extras.datasources import ensure_git_repository
 from nautobot.extras.models import GitRepository
 
 from nautobot_device_onboarding.constants import (
     ONBOARDING_COMMAND_MAPPERS_CONTENT_IDENTIFIER,
     ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(__file__)), "command_mappers"))
 
@@ -41,14 +45,68 @@ def get_git_repo_parser_path(parser_type):
     return None
 
 
-def add_platform_parsing_info():
-    """Merges platform command mapper from repo or defaults."""
+def ensure_command_mappers_repo(repository_record, logger=None, raise_on_error=False):
+    """Ensure the command mappers Git repository is cloned on the worker running this job.
+
+    Args:
+        repository_record (GitRepository): Repository to ensure the state of.
+        logger (NornirLogger): Optional logger to write results to the job result log.
+        raise_on_error (bool): Re-raise instead of falling back to the app provided defaults.
+
+    Returns:
+        bool: True if the local clone is usable, False otherwise.
+    """
+    logger = logger or LOGGER
+    try:
+        ensure_git_repository(repository_record, head=repository_record.current_head or None)
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        logger.error(
+            f"Failed to refresh command mapper Git repository '{repository_record.name}' on this worker: {err}"
+        )
+        if raise_on_error:
+            raise
+        logger.warning(
+            "Falling back to the app provided default command mappers. Command mappers and parsers "
+            f"from '{repository_record.name}' will NOT be applied."
+        )
+        return False
+    logger.debug(
+        f"Command mapper Git repository '{repository_record.name}' is present at "
+        f"{repository_record.filesystem_path}."
+    )
+    return True
+
+
+def add_platform_parsing_info(logger=None, raise_on_repo_error=False):
+    """Merges platform command mapper from repo or defaults.
+
+    Args:
+        logger (NornirLogger): Optional logger to write results to the job result log.
+        raise_on_repo_error (bool): Fail instead of falling back to the app provided defaults when
+            the Git repository cannot be refreshed or read.
+
+    Returns:
+        dict: Command mappers keyed by network driver.
+    """
+    logger = logger or LOGGER
+    command_mappers_repo_path = {}
     repository_record = get_git_repo()
     if repository_record:
-        repo_data_dir = os.path.join(repository_record.filesystem_path, ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER)
-        command_mappers_repo_path = load_command_mappers_from_dir(repo_data_dir)
-    else:
-        command_mappers_repo_path = {}
+        if ensure_command_mappers_repo(repository_record, logger=logger, raise_on_error=raise_on_repo_error):
+            repo_data_dir = os.path.join(
+                repository_record.filesystem_path, ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER
+            )
+            if os.path.isdir(repo_data_dir):
+                command_mappers_repo_path = load_command_mappers_from_dir(repo_data_dir)
+            else:
+                message = (
+                    f"Git repository '{repository_record.name}' does not contain the expected directory "
+                    f"'{ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER}' at {repo_data_dir}. Using the app "
+                    "provided default command mappers only."
+                )
+                logger.error(message)
+                if raise_on_repo_error:
+                    raise FileNotFoundError(message)
     command_mapper_defaults = load_command_mappers_from_dir(DATA_DIR)
     merged_command_mappers = {**command_mapper_defaults, **command_mappers_repo_path}
     return merged_command_mappers

--- a/nautobot_device_onboarding/tests/test_empty_inventory.py
+++ b/nautobot_device_onboarding/tests/test_empty_inventory.py
@@ -1,6 +1,7 @@
 """Test empty inventory creation."""
 
 import unittest
+from unittest import mock
 
 from nautobot_device_onboarding.nornir_plays.empty_inventory import EmptyInventory
 
@@ -19,3 +20,9 @@ class TestEmptyInventory(unittest.TestCase):
 
     def test_initialize_empty_inventory_defaults(self):
         self.assertEqual(list(self.inv.defaults.data.keys()), ["platform_parsing_info", "network_driver_mappings"])
+
+    @mock.patch("nautobot_device_onboarding.nornir_plays.empty_inventory.add_platform_parsing_info")
+    def test_load_passes_logger_through(self, mock_add_platform_parsing_info):
+        logger = mock.MagicMock()
+        EmptyInventory(logger=logger, raise_on_repo_error=True).load()
+        mock_add_platform_parsing_info.assert_called_once_with(logger=logger, raise_on_repo_error=True)

--- a/nautobot_device_onboarding/tests/test_transform.py
+++ b/nautobot_device_onboarding/tests/test_transform.py
@@ -14,8 +14,10 @@ from nautobot.extras.models import GitRepository, JobResult
 
 from nautobot_device_onboarding.constants import (
     ONBOARDING_COMMAND_MAPPERS_CONTENT_IDENTIFIER,
+    ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER,
 )
 from nautobot_device_onboarding.nornir_plays.transform import (
+    DATA_DIR,
     add_platform_parsing_info,
     get_git_repo,
     load_command_mappers_from_dir,
@@ -29,6 +31,14 @@ class TestTransformNoGitRepo(TestCase):
 
     def setUp(self):
         self.yaml_file_dir = f"{MOCK_DIR}/command_mappers/"
+
+    @mock.patch("nautobot_device_onboarding.nornir_plays.transform.ensure_git_repository")
+    @mock.patch("nautobot_device_onboarding.nornir_plays.transform.GitRepository.objects.get")
+    def test_add_platform_parsing_info_no_git_repo_skips_ensure(self, mock_repo_get, mock_ensure):
+        """With no command mapper repo, the git repo must never be touched."""
+        mock_repo_get.side_effect = ObjectDoesNotExist
+        add_platform_parsing_info()
+        mock_ensure.assert_not_called()
 
     @mock.patch("nautobot_device_onboarding.nornir_plays.transform.GitRepository.objects.get")
     def test_add_platform_parsing_info_sane_defaults(self, mock_repo_get):
@@ -146,6 +156,88 @@ class TestTransformWithGitRepo(TransactionTestCase):
                 }
                 merged_mappers = add_platform_parsing_info()
                 self.assertEqual(expected_dict, merged_mappers)
+
+
+@mock.patch("nautobot.extras.datasources.git.GitRepo")
+class TestEnsureCommandMappersRepo(TestCase):
+    """Testing that the command mapper repo is cloned on the worker running the job."""
+
+    def setUp(self):
+        super().setUp()
+        GitRepository.objects.filter(provided_contents__contains=ONBOARDING_COMMAND_MAPPERS_CONTENT_IDENTIFIER).delete()
+        self.repo = GitRepository(
+            name="Test Git Repo",
+            remote_url="http://localhost/git.git",
+            provided_contents=[ONBOARDING_COMMAND_MAPPERS_CONTENT_IDENTIFIER],
+        )
+        self.repo.save()
+        self.default_mappers = load_command_mappers_from_dir(DATA_DIR)
+        self.logger = mock.MagicMock()
+        return mock.DEFAULT
+
+    @staticmethod
+    def populate_repo(repository_record, *args, **kwargs):
+        """Simulate ensure_git_repository cloning the repo onto this worker."""
+        mappers_dir = os.path.join(repository_record.filesystem_path, ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER)
+        os.makedirs(mappers_dir, exist_ok=True)
+        with open(os.path.join(mappers_dir, "foo_bar.yml"), "w", encoding="utf-8") as file_handle:
+            yaml.dump({"sync_devices": {"serial": {"commands": []}}}, file_handle)
+        return True
+
+    @mock.patch("nautobot_device_onboarding.nornir_plays.transform.ensure_git_repository")
+    def test_add_platform_parsing_info_ensures_repo_on_worker(self, mock_ensure, *args):
+        """The repo must be refreshed on whichever worker is executing the job."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.settings(GIT_ROOT=tempdir):
+                mock_ensure.side_effect = self.populate_repo
+                add_platform_parsing_info(logger=self.logger)
+        mock_ensure.assert_called_once_with(self.repo, head=self.repo.current_head or None)
+
+    @mock.patch("nautobot_device_onboarding.nornir_plays.transform.ensure_git_repository")
+    def test_add_platform_parsing_info_clones_when_filesystem_path_missing(self, mock_ensure, *args):
+        """Regression test for #609: a worker with no local clone must not raise FileNotFoundError."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.settings(GIT_ROOT=tempdir):
+                # The repo directory does not exist until ensure_git_repository creates it.
+                self.assertFalse(os.path.isdir(self.repo.filesystem_path))
+                mock_ensure.side_effect = self.populate_repo
+                command_mappers = add_platform_parsing_info(logger=self.logger)
+        self.assertIn("foo_bar", command_mappers)
+        self.assertEqual(sorted([*self.default_mappers, "foo_bar"]), sorted(command_mappers))
+        self.logger.error.assert_not_called()
+
+    @mock.patch("nautobot_device_onboarding.nornir_plays.transform.ensure_git_repository")
+    def test_add_platform_parsing_info_missing_dir_after_ensure_falls_back(self, mock_ensure, *args):
+        """A repo without an onboarding_command_mappers directory logs an error instead of raising."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.settings(GIT_ROOT=tempdir):
+                mock_ensure.return_value = False
+                command_mappers = add_platform_parsing_info(logger=self.logger)
+        self.assertEqual(sorted(self.default_mappers), sorted(command_mappers))
+        self.logger.error.assert_called_once()
+        self.assertIn(ONBOARDING_COMMAND_MAPPERS_REPOSITORY_FOLDER, self.logger.error.call_args[0][0])
+
+    @mock.patch("nautobot_device_onboarding.nornir_plays.transform.ensure_git_repository")
+    def test_add_platform_parsing_info_ensure_failure_logs_error_and_falls_back(self, mock_ensure, *args):
+        """A git failure must be surfaced as an error, not silently swallowed."""
+        mock_ensure.side_effect = Exception("authentication failed")
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.settings(GIT_ROOT=tempdir):
+                command_mappers = add_platform_parsing_info(logger=self.logger)
+        self.assertEqual(sorted(self.default_mappers), sorted(command_mappers))
+        self.logger.error.assert_called_once()
+        self.assertIn("authentication failed", self.logger.error.call_args[0][0])
+        self.logger.warning.assert_called_once()
+
+    @mock.patch("nautobot_device_onboarding.nornir_plays.transform.ensure_git_repository")
+    def test_add_platform_parsing_info_ensure_failure_raises_when_fail_job_on_task_failure(self, mock_ensure, *args):
+        """With the job's fail fast option set, a git failure must fail the job."""
+        mock_ensure.side_effect = Exception("authentication failed")
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.settings(GIT_ROOT=tempdir):
+                with self.assertRaises(Exception):
+                    add_platform_parsing_info(logger=self.logger, raise_on_repo_error=True)
+        self.logger.error.assert_called_once()
 
 
 @mock.patch("nautobot.extras.datasources.git.GitRepo")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Device Onboarding! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #609

## What's Changed

This PR adds a step to the Sync Jobs to ensure the command mapper repo is synced before running.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [N/A] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [N/A] Documentation Updates (when adding/changing features)
- [N/A] Outline Remaining Work, Constraints from Design

NTC-6476